### PR TITLE
Fixed issue #604: Content-length greater than actual content w/ range request

### DIFF
--- a/modules/org.restlet/src/org/restlet/engine/io/BioUtils.java
+++ b/modules/org.restlet/src/org/restlet/engine/io/BioUtils.java
@@ -269,7 +269,10 @@ public final class BioUtils {
         if (representation.getRange() == null) {
             return representation.getSize();
         } else if (representation.getRange().getSize() != Range.SIZE_MAX) {
-            return representation.getRange().getSize();
+            if(representation.hasKnownSize() && representation.getRange().getSize() > representation.getSize())
+        		return representation.getSize();
+        	else
+        		return representation.getRange().getSize();
         } else if (representation.hasKnownSize()) {
             if (representation.getRange().getIndex() != Range.INDEX_LAST) {
                 return representation.getSize()


### PR DESCRIPTION
For getAvailableSize, used when setting Content-length, I added a conditional to return the size of the actual content if it was smaller than the size of the range request.
