### PR TITLE
Add custom Content-Range unit names.

### DIFF
--- a/modules/org.restlet/src/org/restlet/data/Range.java
+++ b/modules/org.restlet/src/org/restlet/data/Range.java
@@ -68,6 +68,12 @@ public class Range {
      * available from the index, then use the {@value #SIZE_MAX} constant.
      */
     private volatile long size;
+    
+    /**
+     * Specifies the unit of the range. The HTTP/1.1 protocol specifies
+     * only 'bytes', but other ranges are allowed {@link http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.12}
+     */
+    private volatile String unitName = "bytes";
 
     /**
      * Default constructor defining a range starting on the first byte and with
@@ -187,4 +193,22 @@ public class Range {
     public void setSize(long size) {
         this.size = size;
     }
+
+    /**
+     * Returns the name of the range unit name.
+     * @return 
+     * 			The name of the range
+     */
+	public String getUnitName() {
+		return unitName;
+	}
+	
+	/**
+	 * Setter to define the unit name.
+	 * @param unitName 
+	 * 			with the name of the unit.
+	 */
+	public void setUnitName(String unitName) {
+		this.unitName = unitName;
+	}
 }

--- a/modules/org.restlet/src/org/restlet/engine/header/RangeWriter.java
+++ b/modules/org.restlet/src/org/restlet/engine/header/RangeWriter.java
@@ -66,7 +66,9 @@ public class RangeWriter extends HeaderWriter<Range> {
      * @return {@code range} formatted
      */
     public static String write(Range range, long size) {
-        StringBuilder b = new StringBuilder("bytes ");
+        StringBuilder b = new StringBuilder();
+        b.append(range.getUnitName());
+        b.append(' ');
 
         if (range.getIndex() >= Range.INDEX_FIRST) {
             b.append(range.getIndex());


### PR DESCRIPTION
This pull request contains some code to allow the user to set a custom Content-Range name.
Typically, the HTTP/1.1 protocol expects the "bytes" keyword in a Content-Range, e.g. 
Content-Range: bytes 0-32/128

Some Web-Frameworks like Dojo expect another Range-Unit. It is specified by the HTTP protocol to use custom units for Content-Ranges: http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.12

The documentation of Dojo says: http://dojotoolkit.org/reference-guide/1.7/dojox/data/JsonRestStore.html

"The server should respond with a Content-Range header to indicate how many items are being returned and how many total items exist:
Content-Range: items 0-24/66"
