### PR TITLE
Small fix for BNode parsing

### DIFF
--- a/modules/org.restlet.ext.rdf/src/org/restlet/ext/rdf/internal/turtle/RdfTurtleReader.java
+++ b/modules/org.restlet.ext.rdf/src/org/restlet/ext/rdf/internal/turtle/RdfTurtleReader.java
@@ -313,6 +313,9 @@ public class RdfTurtleReader extends RdfNTriplesReader {
                 break;
             case ']':
                 break;
+            case '.':
+                step();
+                break;                
             default:
                 if (!isEndOfFile(getChar())) {
                     blankNode.getLexicalUnits().add(


### PR DESCRIPTION
This fixes parsing files using a bnode construct, such as that one:

@PreFix ids: http://idswrapper.appspot.com/eldis/resource/country/ .
@PreFix idsv: http://idswrapper.appspot.com/vocabulary# .
@PreFix owl: http://www.w3.org/2002/07/owl# .

ids:A1078
owl:sameAs [
a idsv:Country.
].
