### PR TITLE
fix issue 559 - (strict conneg should evaluate media type parameters)

### DIFF
--- a/modules/org.restlet.test/src/org/restlet/test/data/MediaTypeTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/data/MediaTypeTestCase.java
@@ -161,6 +161,95 @@ public class MediaTypeTestCase extends RestletTestCase {
         assertFalse(mt2.includes(mt1));
 
         assertFalse(mt1.includes(null));
+
+        /*
+         * test inclusion for media types with parameters. The rule is: media
+         * type A includes media type B iff for each parameter name/value pair
+         * in A, B contains the same parameter name/value pair
+         */
+
+        // set up test data
+
+        MediaType typeWithNoParams = new MediaType("application/sometype");
+
+        Series<Parameter> singleParam = new Series<Parameter>(Parameter.class);
+        singleParam.add(new Parameter("name1", "value1"));
+        MediaType typeWithSingleParam = new MediaType("application/sometype",
+                singleParam);
+
+        Series<Parameter> singleMatchingParam = new Series<Parameter>(
+                Parameter.class);
+        singleMatchingParam.add(new Parameter("name1", "value1"));
+        MediaType typeWithSingleMatchingParam = new MediaType(
+                "application/sometype", singleMatchingParam);
+
+        Series<Parameter> singleNonMatchingParamValue = new Series<Parameter>(
+                Parameter.class);
+        singleNonMatchingParamValue.add(new Parameter("name1", "value2"));
+        MediaType typeWithSingleNonMatchingParamValue = new MediaType(
+                "application/sometype", singleNonMatchingParamValue);
+
+        Series<Parameter> singleNonMatchingParamName = new Series<Parameter>(
+                Parameter.class);
+        singleNonMatchingParamName.add(new Parameter("name2", "value2"));
+        MediaType typeWithSingleNonMatchingParamName = new MediaType(
+                "application/sometype", singleNonMatchingParamName);
+
+        Series<Parameter> twoParamsOneMatches = new Series<Parameter>(
+                Parameter.class);
+        twoParamsOneMatches.add(new Parameter("name1", "value1"));
+        twoParamsOneMatches.add(new Parameter("name2", "value2"));
+        MediaType typeWithTwoParamsOneMatches = new MediaType(
+                "application/sometype", twoParamsOneMatches);
+
+        // SCENARIO 1: test whether type with no params includes type with one
+        // param
+
+        assertTrue(typeWithNoParams.includes(typeWithSingleParam, true));
+        assertTrue(typeWithNoParams.includes(typeWithSingleParam, false));
+
+        // SCENARIO 2: test whether type with one param includes type with no
+        // params
+
+        assertTrue(typeWithSingleParam.includes(typeWithNoParams, true));
+        assertFalse(typeWithSingleParam.includes(typeWithNoParams, false));
+
+        // SCENARIO 3: test whether type with single param includes type with
+        // matching single param.
+        // Note that this is distinct from testing whether a type includes
+        // itself, as there is a special check for that.
+        assertTrue(typeWithSingleParam.includes(typeWithSingleMatchingParam,
+                true));
+        assertTrue(typeWithSingleParam.includes(typeWithSingleMatchingParam,
+                false));
+
+        // SCENARIO 4: test whether type with single param includes type with
+        // single param having different name
+        assertTrue(typeWithSingleParam.includes(
+                typeWithSingleNonMatchingParamName, true));
+        assertFalse(typeWithSingleParam.includes(
+                typeWithSingleNonMatchingParamName, false));
+
+        // SCENARIO 5: test whether type with single param includes type with
+        // single param having same name but different value
+        assertTrue(typeWithSingleParam.includes(
+                typeWithSingleNonMatchingParamValue, true));
+        assertFalse(typeWithSingleParam.includes(
+                typeWithSingleNonMatchingParamValue, false));
+
+        // SCENARIO 6: test whether type with single param includes type with
+        // two params, one matching
+        assertTrue(typeWithSingleParam.includes(typeWithTwoParamsOneMatches,
+                true));
+        assertTrue(typeWithSingleParam.includes(typeWithTwoParamsOneMatches,
+                false));
+
+        // SCENARIO 7: test whether type with two params includes type with
+        // single matching param
+        assertTrue(typeWithTwoParamsOneMatches.includes(typeWithSingleParam,
+                true));
+        assertFalse(typeWithTwoParamsOneMatches.includes(typeWithSingleParam,
+                false));
     }
 
     public void testMostSpecificMediaType() {

--- a/modules/org.restlet/src/org/restlet/data/MediaType.java
+++ b/modules/org.restlet/src/org/restlet/data/MediaType.java
@@ -1073,11 +1073,17 @@ public final class MediaType extends Metadata {
         return SystemUtils.hashCode(super.hashCode(), getParameters());
     }
 
+    /** {@inheritDoc} */
+    @Override
+    public boolean includes(Metadata included) {
+        return includes(included, true);
+    }
+
     /**
-     * Indicates if a given media type is included in the current one. The test
-     * is true if both types are equal or if the given media type is within the
-     * range of the current one. For example, ALL includes all media types.
-     * Parameters are ignored for this comparison. A null media type is
+     * Indicates if a given media type is included in the current one, with the
+     * possibility to ignore parameters. The test is true if both types are
+     * equal or if the given media type is within the range of the current one.
+     * For example, ALL includes all media types. A null media type is
      * considered as included into the current one.
      * <p>
      * Examples:
@@ -1088,11 +1094,13 @@ public final class MediaType extends Metadata {
      * 
      * @param included
      *            The media type to test for inclusion.
+     * @param ignoreParameters
+     *            Indicates if parameters should be ignored during comparison.
      * @return True if the given media type is included in the current one.
      * @see #isCompatible(Metadata)
      */
-    @Override
-    public boolean includes(Metadata included) {
+
+    public boolean includes(Metadata included, boolean ignoreParameters) {
         boolean result = equals(ALL) || equals(included);
 
         if (!result && (included instanceof MediaType)) {
@@ -1101,7 +1109,32 @@ public final class MediaType extends Metadata {
             if (getMainType().equals(includedMediaType.getMainType())) {
                 // Both media types are different
                 if (getSubType().equals(includedMediaType.getSubType())) {
-                    result = true;
+                    if (ignoreParameters) {
+                        result = true;
+                    } else {
+                        // check parameters - media type A includes media type B
+                        // iff for each param name/value pair in A, B contains
+                        // the same name/value.
+                        boolean paramsMatch = true;
+                        for (Parameter thisParam : getParameters()) {
+                            Parameter includedParam = includedMediaType
+                                    .getParameters().getFirst(
+                                            thisParam.getName());
+                            // if there was no param with the same name, or the
+                            // param with the same name had a different vlaue,
+                            // then no match
+                            if (includedParam == null
+                                    || !thisParam.getValue().equals(
+                                            includedParam.getValue())) {
+                                paramsMatch = false;
+                                break;
+                            }
+                        }
+                        if (paramsMatch) {
+                            result = true;
+                        }
+                    }
+
                 } else if (getSubType().equals("*")) {
                     result = true;
                 } else if (getSubType().startsWith("*+")

--- a/modules/org.restlet/src/org/restlet/engine/application/StrictConneg.java
+++ b/modules/org.restlet/src/org/restlet/engine/application/StrictConneg.java
@@ -249,7 +249,28 @@ public class StrictConneg extends Conneg {
      * @return The score.
      */
     public float scoreMediaType(MediaType mediaType) {
-        return scoreMetadata(mediaType, getMediaTypePrefs());
+        float result = -1.0F;
+        float current;
+
+        if (mediaType != null) {
+            for (Preference<MediaType> pref : getMediaTypePrefs()) {
+                // passing false as 2nd arg causes media type params to be
+                // considered in inclusion test
+                if (pref.getMetadata().includes(mediaType, false)) {
+                    current = pref.getQuality();
+                } else {
+                    current = -1.0F;
+                }
+
+                if (current > result) {
+                    result = current;
+                }
+            }
+        } else {
+            result = 0.0F;
+        }
+
+        return result;
     }
 
     /**
@@ -349,7 +370,8 @@ public class StrictConneg extends Conneg {
                                     + (mediaTypeScore * 3.0F)
                                     + (characterSetScore * 2.0F)
                                     + (encodingScore * 1.0F) + (annotationScore * 2.0F)) / 12.0F;
-                            // Take into account the affinity with the input entity
+                            // Take into account the affinity with the input
+                            // entity
                             result = result
                                     * ((VariantInfo) variant).getInputScore();
                         } else {


### PR DESCRIPTION
[Note: this pull request replaces a previous one.]

1) Added method 
MediaType.includes(Metadata included, boolean ignoreParameters) 
which is similar to the prior 
MediaType.includes(Metadata included)
but includes the following logic:
If ignoreParameters is true, behave as before. Otherwise, loop
through the media type parameters of "this". Consider "this" to
include "included" iff for each param name/value pair in "this", "included"
contains the same name/value.
2) Changed the prior MediaType.includes(Metadata included) method so that it 
passes through to the new method, supplying true for the 2nd argument and 
thus maintaining the original behavior for callers of that method signature.

3) Replaced the implementation of
StrictConneg.scoreMediaType(MediaType mediaType) with code copied from
scoreMetadata(T, List>), modified slightly to pass false
for the new 2nd argument to MediaType.includes(). Thus, under strict
content negotiation, media type parameters will be considered in the
inclusion test.

Also added unit tests for new MediaType.includes() functionality.
