### PR TITLE
change of getAuthSession() in AuthorizationBaseServerResource.java

### DIFF
--- a/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/AuthorizationBaseServerResource.java
+++ b/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/AuthorizationBaseServerResource.java
@@ -86,7 +86,12 @@ public class AuthorizationBaseServerResource extends OAuthServerResource {
      */
     protected AuthSession getAuthSession() {
         // Get some basic information
-        String sessionId = getCookies().getFirstValue(ClientCookieID);
+        String sessionId = (String) getRequest().getAttributes().get(
+                ClientCookieID);
+        
+        if (sessionId == null)
+            sessionId = getCookies().getFirstValue(ClientCookieID);
+        
         getLogger().fine("sessionId = " + sessionId);
 
         AuthSession session = (sessionId == null) ? null


### PR DESCRIPTION
When redirecting from the auth_page it will set the cookie but it will not be available yet after the redirect. It is however present in the attributes of the request. This causes NPE in certain cases.

We noticed that in previous version of this extension it was indeed fetched from the attributes from the request. It fixed our problem we were having.
