### PR TITLE
Changing the Finder to use a factory for creating resources to allow control over object instantiation

### DIFF
--- a/modules/org.restlet/module.xml
+++ b/modules/org.restlet/module.xml
@@ -125,9 +125,11 @@
          <exclude name="src/org/restlet/representation/ReaderRepresentation.java" />
          <exclude name="src/org/restlet/representation/WritableRepresentation.java" />
          <exclude name="src/org/restlet/representation/WriterRepresentation.java" />
+         <exclude name="src/org/restlet/resource/DefaultObjectFactory.java" />
          <exclude name="src/org/restlet/resource/Directory.java" />
          <exclude name="src/org/restlet/resource/Finder.java" />
          <exclude name="src/org/restlet/resource/Handler.java" />
+         <exclude name="src/org/restlet/resource/ObjectFactory.java" />
          <exclude name="src/org/restlet/resource/ServerResource.java" />
          <exclude name="src/org/restlet/routing/**" />
          <exclude name="src/org/restlet/security/**" />

--- a/modules/org.restlet/src/org/restlet/Context.java
+++ b/modules/org.restlet/src/org/restlet/Context.java
@@ -144,6 +144,10 @@ public class Context {
     /** The executor service. */
     private volatile ScheduledExecutorService executorService;
 
+	// [ifndef gwt] member
+    /** The object factory to use */
+    private volatile org.restlet.resource.ObjectFactory objectFactory;
+
     /**
      * Constructor. Writes log messages to "org.restlet".
      */
@@ -172,7 +176,9 @@ public class Context {
         this.defaultEnroler = null;
         this.serverDispatcher = null;
         this.defaultVerifier = null;
+        this.objectFactory = new org.restlet.resource.DefaultObjectFactory();
         // [enddef]
+
     }
 
     /**
@@ -318,6 +324,16 @@ public class Context {
         return this.serverDispatcher;
     }
 
+	// [ifndef gwt] method
+    /**
+     * Returns the object factory that should be used to instantiate objects.
+     * 
+     * @return The object factory.
+     */
+    public org.restlet.resource.ObjectFactory getObjectFactory() {
+        return this.objectFactory;
+    }
+
     /**
      * Sets the modifiable map of attributes. This method clears the current map
      * and puts all entries in the parameter map.
@@ -430,6 +446,17 @@ public class Context {
      */
     public void setServerDispatcher(Restlet serverDispatcher) {
         this.serverDispatcher = serverDispatcher;
+    }
+
+	// [ifndef gwt] method
+    /**
+     * Sets the object factory.
+     * 
+     * @param objectFactory
+     *            The new object factory.
+     */
+    public void setObjectFactory(org.restlet.resource.ObjectFactory objectFactory) {
+    	this.objectFactory = objectFactory;
     }
 
 }

--- a/modules/org.restlet/src/org/restlet/engine/util/ChildContext.java
+++ b/modules/org.restlet/src/org/restlet/engine/util/ChildContext.java
@@ -35,6 +35,7 @@ package org.restlet.engine.util;
 
 import org.restlet.Context;
 import org.restlet.Restlet;
+import org.restlet.resource.ObjectFactory;
 import org.restlet.engine.log.LogUtils;
 
 /**
@@ -65,6 +66,7 @@ public class ChildContext extends Context {
                 .getServerDispatcher() : null);
         setExecutorService((parentContext != null) ? new WrapperScheduledExecutorService(
                 parentContext.getExecutorService()) : null);
+		setObjectFactory(null);
     }
 
     /**
@@ -96,5 +98,20 @@ public class ChildContext extends Context {
         setLogger(LogUtils.getLoggerName(this.parentContext.getLogger()
                 .getName(), child));
     }
+
+	/**
+	 * Gets the parent's object factory unless a specific object factory
+	 * has been set on this context
+	 *
+	 * @return The object factory
+	 */
+	@Override
+	public ObjectFactory getObjectFactory() {
+		if(super.getObjectFactory() != null) {
+			return super.getObjectFactory();
+		}
+		return getParentContext().getObjectFactory();
+	}
+
 
 }

--- a/modules/org.restlet/src/org/restlet/resource/DefaultObjectFactory.java
+++ b/modules/org.restlet/src/org/restlet/resource/DefaultObjectFactory.java
@@ -1,0 +1,23 @@
+package org.restlet.resource;
+
+
+/**
+ * Default object factory implementation, uses reflection to instantiate new
+ * objects.
+ * 
+ * @author Raniz
+ *
+ */
+public class DefaultObjectFactory
+	implements ObjectFactory
+{
+	/** Singleton instance for easy access and memory saving purposes */
+	public static DefaultObjectFactory INSTANCE = new DefaultObjectFactory();
+
+	@Override
+	public <T>T getInstance(Class<T> targetClass) throws Exception
+	{
+		return targetClass.newInstance();
+	}
+
+}

--- a/modules/org.restlet/src/org/restlet/resource/Finder.java
+++ b/modules/org.restlet/src/org/restlet/resource/Finder.java
@@ -153,8 +153,10 @@ public class Finder extends Restlet {
 
         if (targetClass != null) {
             try {
-                // Invoke the default constructor
-                result = targetClass.newInstance();
+            	ObjectFactory factory = getContext() != null
+            		? getContext().getObjectFactory()
+            		: DefaultObjectFactory.INSTANCE;
+                result = factory.getInstance(targetClass);
             } catch (Exception e) {
                 getLogger()
                         .log(Level.WARNING,

--- a/modules/org.restlet/src/org/restlet/resource/ObjectFactory.java
+++ b/modules/org.restlet/src/org/restlet/resource/ObjectFactory.java
@@ -1,0 +1,23 @@
+package org.restlet.resource;
+
+
+/**
+ * Factory for instantiating objects.
+ * 
+ * @author Raniz
+ *
+ */
+public interface ObjectFactory
+{
+
+	/**
+	 * Gets an instance of a class.
+	 * 
+	 * @param targetClass
+     *            The class that should be instantiated.
+	 * 
+	 * @return An instance of targetClass
+	 */
+	<T> T getInstance(Class<T> targetClass) throws Exception;
+
+}


### PR DESCRIPTION
I make heavy use of Guice for dependency injection in our projects and I had previously implemented this in a way similar to how the guice extension is implemented.

When I started using Authorizer and Authenticator, however, everything fell apart since I can't control how the Authorizer and Authenticator creates their finders without overriding those methods in every subclass. This mean that resources set after an Authorizer or Authenticator caused errors since their constructors relied on dependency injection in the constructors.

I needed a different solution and the best one seemed to be to allow modification of how the Finder instantiates new instances of resources.

I added an ObjectFactory interface with a default implementation that works exactly as the old Finder. The object factory is stored in the Context and the Finder fetches it from there whenever a new instance is required. I had to modify ChildContext to defer to it's parent if an explict object factory hadn't been set on the child context, otherwise child contexts created before the object factory is set would not inherit the custom object factory.

The changes required to implement this are light and previous functionality is preserved while still allowing users of Restlet to take control of object instantiation and either handle it themselves or passing control over to an external framework such as Guice by providing their own implementation of ObjectFactory.

Here's an example on how I use this:

``` java
    @SuppressWarnings("unchecked")
    @Override
    public Router createInboundRoot()
    {
        // Change the object factory to the Guice implementation
        getContext().setObjectFactory(injector.get(GuiceObjectFactory.class));

        Router router = new Router(getContext());

        AddressAuthorizer authorizer = new AddressAuthorizer.Builder()
            .denyAll()
            .allow("127.0.0.1/24")
            .build();

        // This is very important, otherwise Guice injecton won't work
        // for resources protected by the authorizer
        authorizer.setContext(router.getContext());

        authorizer.setNext(HelloWorldResource.class);
        router.attach("/", authorizer);

        return router;
    }
```
