### PR TITLE
Log exception on writing to and closing WritableByteChannel as warning

### DIFF
--- a/modules/org.restlet/src/org/restlet/engine/adapter/ServerAdapter.java
+++ b/modules/org.restlet/src/org/restlet/engine/adapter/ServerAdapter.java
@@ -100,7 +100,7 @@ public class ServerAdapter extends Adapter {
                         response.getStatus().getReasonPhrase());
             }
         } catch (Exception e) {
-            getLogger().log(Level.INFO,
+            getLogger().log(Level.WARNING,
                     "Exception intercepted while adding the response headers",
                     e);
             response.getHttpCall().setStatusCode(

--- a/modules/org.restlet/src/org/restlet/engine/io/NioUtils.java
+++ b/modules/org.restlet/src/org/restlet/engine/io/NioUtils.java
@@ -211,7 +211,7 @@ public class NioUtils {
                         wbc = pipe.sink();
                         representation.write(wbc);
                     } catch (IOException ioe) {
-                        Context.getCurrentLogger().log(Level.FINE,
+                        Context.getCurrentLogger().log(Level.WARNING,
                                 "Error while writing to the piped channel.",
                                 ioe);
                     } finally {
@@ -220,7 +220,7 @@ public class NioUtils {
                                 wbc.close();
                             } catch (IOException e) {
                                 Context.getCurrentLogger()
-                                        .log(Level.FINE,
+                                        .log(Level.WARNING,
                                                 "Error while closing to the piped channel.",
                                                 e);
                             }


### PR DESCRIPTION
Currently, when an exception occurs while writing a representation to the byte channel, e.g. in a custom Jackson converter, the exception is swallowed and only logged at level 'fine'. The request completes successfully (with a 200 or 204), so it appear as if nothing went wrong.

Logging it at level 'warning' will at least make it visible in the console (with default settings). However, a better solution would be to let the exception propagate up the call stack, making it impossible to miss.
