### PR TITLE
Fix maven issues for gson.

### DIFF
--- a/libraries/com.google.gson_2.2/library.xml
+++ b/libraries/com.google.gson_2.2/library.xml
@@ -10,7 +10,7 @@
 	<package id="gson" name="com.google.code.gson">
 		<maven>
 			<groupId>com.google.code.gson</groupId>
-                        <artefactId>gson</artefactId>
+                        <artifactId>gson</artifactId>
 		</maven>
 	</package>
 	<distributions>


### PR DESCRIPTION
Trying to resolve the following issue:

Failed to execute goal on project: Could not resolve dependencies for project: Failed to collect dependencies for [org.restlet.jse:org.restlet:jar:2.2-M5 (compile), org.restlet.jse:org.restlet.ext.gson:jar:2.2-M5 (compile)]: Failed to read artifact descriptor for com.google.code.gson:com.google.code.gson:jar:2.2.4: Could not transfer artifact com.google.code.gson:com.google.code.gson:pom:2.2.4 from/to maven1-java (http://download.java.net/maven/1): No connector available to access repository maven1-java (http://download.java.net/maven/1) of type legacy using the available factories WagonRepositoryConnectorFactory -> [Help 1]

I think it's because of the spelling (artefact vs artifact).
