### PR TITLE
fix #848: ServerResource throws away response entities

### DIFF
--- a/modules/org.restlet/src/org/restlet/resource/ServerResource.java
+++ b/modules/org.restlet/src/org/restlet/resource/ServerResource.java
@@ -1018,7 +1018,7 @@ public abstract class ServerResource extends Resource {
                     result = doHandle();
                 }
 
-                if (!getResponse().isEntityAvailable()) {
+                if (result != null && !getResponse().isEntityAvailable()) {
                     // If the user manually set the entity, keep it
                     getResponse().setEntity(result);
                 }


### PR DESCRIPTION
Do not replace existing and available but empty response entities with `null`.
