### PR TITLE
Relax ProductReader to accept all token characters

### DIFF
--- a/modules/org.restlet.test/src/org/restlet/test/data/ProductTokenTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/data/ProductTokenTestCase.java
@@ -62,7 +62,7 @@ public class ProductTokenTestCase extends RestletTestCase {
         final String userAgent8 = "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/521.25 (KHTML, like Gecko) Safari/521.24";
         final String userAgent9 = "Opera/9.00 (Macintosh; PPC Mac OS X; U; en)";
         final String userAgent10 = "Wget/1.9";
-        final String userAgent11 = "Restlet-Framework/2.1-SNAPSHOT";
+        final String userAgent11 = "Restlet-Framework/2.2-SNAPSHOT";
 
         ClientInfo clientInfo = new ClientInfo();
         clientInfo.setAgent(userAgent1);
@@ -129,7 +129,7 @@ public class ProductTokenTestCase extends RestletTestCase {
         clientInfo.setAgent(userAgent11);
         product = clientInfo.getMainAgentProduct();
         assertEquals("Restlet-Framework", product.getName());
-        assertEquals("2.1-SNAPSHOT", product.getVersion());
+        assertEquals("2.2-SNAPSHOT", product.getVersion());
 
         clientInfo = new ClientInfo();
         clientInfo.setAgent(userAgent7);
@@ -149,6 +149,7 @@ public class ProductTokenTestCase extends RestletTestCase {
         final String userAgent4 = "Mozilla";
         final String userAgent5 = "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-US; rv:1.8) Gecko/20051107 Camino/1.0b1";
         final String userAgent6 = "Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Iceweasel/2.0 (Debian-2.0+dfsg-1)";
+        final String userAgent7 = "Restlet-Framework/2.2-SNAPSHOT";
 
         List<Product> list = ProductReader.read(userAgent1);
         assertEquals(1, list.size());
@@ -201,6 +202,12 @@ public class ProductTokenTestCase extends RestletTestCase {
         assertEquals("Iceweasel", list.get(2).getName());
         assertEquals("2.0", list.get(2).getVersion());
         assertEquals("Debian-2.0+dfsg-1", list.get(2).getComment());
+
+        list = ProductReader.read(userAgent7);
+        assertEquals(1, list.size());
+        assertEquals("Restlet-Framework", list.get(0).getName());
+        assertEquals("2.2-SNAPSHOT", list.get(0).getVersion());
+        assertNull(list.get(0).getComment());
 
         final List<Product> products = new ArrayList<Product>();
         products.add(new Product("Product", "1.2", null));

--- a/modules/org.restlet/src/org/restlet/engine/header/ProductReader.java
+++ b/modules/org.restlet/src/org/restlet/engine/header/ProductReader.java
@@ -74,8 +74,7 @@ public class ProductReader {
             for (index = 0; index < tab.length; index++) {
                 final char c = tab[index];
                 if (insideToken) {
-                    if (((c >= 'a') && (c <= 'z'))
-                            || ((c >= 'A') && (c <= 'Z')) || (c == ' ')) {
+                    if (HeaderUtils.isTokenChar(c) || (c == ' ')) {
                         tokenBuilder.append(c);
                     } else {
                         token = tokenBuilder.toString().trim();


### PR DESCRIPTION
I noticed that `ProductReader` was failing to read `Engine.VERSION_HEADER` because of the '-' character. I changed the code to use `isTokenChar` (previously it was using the equivalent to `isAlpha`).

It looks like `isTokenChar` does not exclude control characters, and the product reader is expected to accept spaces: I was wondering, are those intentional deviations from the specification for compatibility?
