### PR TITLE
Fix issue #865

### DIFF
--- a/modules/org.restlet/src/org/restlet/engine/CompositeHelper.java
+++ b/modules/org.restlet/src/org/restlet/engine/CompositeHelper.java
@@ -210,13 +210,18 @@ public abstract class CompositeHelper<T extends Restlet> extends
         if (getFirstInboundFilter() != null) {
             getFirstInboundFilter().handle(request, response);
         } else {
-            response.setStatus(Status.SERVER_ERROR_INTERNAL);
-            getHelped()
-                    .getLogger()
-                    .log(Level.SEVERE,
-                            "The "
-                                    + getHelped().getClass().getName()
-                                    + " class has no Restlet defined to process calls. Maybe it wasn't properly started.");
+            final Restlet next = this.inboundNext;
+            if (next != null) {
+                next.handle(request, response);
+            } else {
+                response.setStatus(Status.SERVER_ERROR_INTERNAL);
+                getHelped()
+                        .getLogger()
+                        .log(Level.SEVERE,
+                                "The "
+                                        + getHelped().getClass().getName()
+                                        + " class has no Restlet defined to process calls. Maybe it wasn't properly started.");
+            }
         }
     }
 


### PR DESCRIPTION
I figured `getInboundNext()` could have just been used instead of `getFirstInboundFilter()` but I wan't sure if the synchronized access in `handle` would be desirable and opted to add a check to see if there is an `inboundNext`.
