### PR TITLE
Remove System.out calls

### DIFF
--- a/modules/org.restlet.ext.jackson/src/org/restlet/ext/jackson/JacksonRepresentation.java
+++ b/modules/org.restlet.ext.jackson/src/org/restlet/ext/jackson/JacksonRepresentation.java
@@ -201,7 +201,6 @@ public class JacksonRepresentation<T> extends OutputRepresentation {
      */
     protected ObjectMapper createObjectMapper() {
         ObjectMapper result = null;
-        System.out.println("createObjectMapper");
         if (MediaType.APPLICATION_JSON.isCompatible(getMediaType())) {
             JsonFactory jsonFactory = new JsonFactory();
             jsonFactory.configure(Feature.AUTO_CLOSE_TARGET, false);

--- a/modules/org.restlet/src/org/restlet/data/Metadata.java
+++ b/modules/org.restlet/src/org/restlet/data/Metadata.java
@@ -150,10 +150,8 @@ public abstract class Metadata {
      * @see #includes(Metadata)
      */
     public boolean isCompatible(Metadata otherMetadata) {
-        boolean result = (otherMetadata != null)
+        return (otherMetadata != null)
                 && (includes(otherMetadata) || otherMetadata.includes(this));
-        System.out.println("isCompatible " + result);
-        return result;
     }
 
     /**


### PR DESCRIPTION
Just took 2.2.0 from 2.2-RC3 and our console is being flooded by these two `System.out` calls.

Is there any chance of a 2.2.1 to address this?
