### PR TITLE
Potential fix for issue #908

### DIFF
--- a/modules/org.restlet/src/org/restlet/engine/local/EntityClientHelper.java
+++ b/modules/org.restlet/src/org/restlet/engine/local/EntityClientHelper.java
@@ -272,9 +272,14 @@ public abstract class EntityClientHelper extends LocalClientHelper {
                                 Variant entryVariant = entry.getVariant();
 
                                 if (entityVariant.isCompatible(entryVariant)) {
-                                    // The right representation has been found.
-                                    uniqueVariant = entry;
-                                    break;
+                                    if (uniqueVariant != null) {
+                                        // There are multiple compatible representations.
+                                        uniqueVariant = null;
+                                        break;
+                                    } else {
+                                        // The right representation has been found.
+                                        uniqueVariant = entry;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
As mentioned in #908, one potential fix is to not return a representation if there are multiple compatible representations. Though I wonder if a better fix would be to have the `DirectoryServerResource.getRepresentation` method some how tell the local client helper not to attempt any negotiation of it's own.
