### PR TITLE
Bracket IPv6 host names if not bracketed by servlet container. #959

### DIFF
--- a/modules/org.restlet.ext.servlet/src/org/restlet/ext/servlet/internal/ServletCall.java
+++ b/modules/org.restlet.ext.servlet/src/org/restlet/ext/servlet/internal/ServletCall.java
@@ -164,7 +164,14 @@ public class ServletCall extends ServerCall {
      */
     @Override
     public String getHostDomain() {
-        return getRequest().getServerName();
+        String serverName = getRequest().getServerName();
+        
+        // Check if the servlet container returned an unbracketed IPv6 address
+        if (serverName.indexOf(':') != -1 && serverName.indexOf('[') == -1) {
+            return '[' + serverName + ']';
+        } else {
+            return serverName;
+        }
     }
 
     /**


### PR DESCRIPTION
This commit fixes #959 by patching ServletCall, to limit the scope of the fix to just the servlet extension. I'm not sure if this is the Right Way as far as the Restlet developers are concerned, though.
