### PR TITLE
move status.uri, contactemail and homeref to StatusInfoHtmlConverter

### DIFF
--- a/modules/org.restlet.test/src/org/restlet/test/service/StatusServiceTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/service/StatusServiceTestCase.java
@@ -94,7 +94,6 @@ public class StatusServiceTestCase extends RestletTestCase {
         assertEquals(expectedStatus.getCode(), map.get("code"));
         assertEquals(expectedStatus.getDescription(), map.get("description"));
         assertEquals(expectedStatus.getReasonPhrase(), map.get("reasonPhrase"));
-        assertEquals(expectedStatus.getUri(), map.get("uri"));
     }
 
     public void testSerializedException() throws IOException {
@@ -109,7 +108,6 @@ public class StatusServiceTestCase extends RestletTestCase {
                 new Response(request));
 
         // verify
-
         assertEquals(MediaType.APPLICATION_JSON, representation.getMediaType());
         Status401SerializableException e = new JacksonRepresentation<>(
                 representation, Status401SerializableException.class)

--- a/modules/org.restlet/src/org/restlet/engine/application/StatusInfo.java
+++ b/modules/org.restlet/src/org/restlet/engine/application/StatusInfo.java
@@ -41,20 +41,11 @@ public class StatusInfo implements Serializable {
     /** The specification code. */
     private volatile int code;
 
-    /** The email address of the administrator to contact in case of error. */
-    private volatile String contactEmail;
-
     /** The longer description. */
     private volatile String description;
 
-    /** The home URI to propose in case of error. */
-    private volatile String homeRef;
-
     /** The short reason phrase. */
     private volatile String reasonPhrase;
-
-    /** The URI of the specification describing the method. */
-    private volatile String uri;
 
     /**
      * Empty Constructor
@@ -73,33 +64,10 @@ public class StatusInfo implements Serializable {
      *            The short reason phrase.
      */
     public StatusInfo(int code, String description, String reasonPhrase) {
-        this(code, description, reasonPhrase, null, null, null);
-    }
-
-    /**
-     * Constructor.
-     * 
-     * @param code
-     *            The specification code.
-     * @param description
-     *            The longer description.
-     * @param reasonPhrase
-     *            The short reason phrase.
-     * @param contactEmail
-     *            The email address of the administrator to contact in case of
-     *            error.
-     * @param homeRef
-     *            The home URI to propose in case of error.
-     */
-    public StatusInfo(int code, String description, String reasonPhrase,
-            String uri, String contactEmail, String homeRef) {
         super();
         this.code = code;
         this.description = description;
         this.reasonPhrase = reasonPhrase;
-        this.uri = uri;
-        this.contactEmail = contactEmail;
-        this.homeRef = homeRef;
     }
 
     /**
@@ -110,7 +78,7 @@ public class StatusInfo implements Serializable {
      */
     public StatusInfo(Status status) {
         this(status.getCode(), status.getDescription(), status
-                .getReasonPhrase(), status.getUri(), null, null);
+                .getReasonPhrase());
     }
 
     /**
@@ -123,18 +91,8 @@ public class StatusInfo implements Serializable {
     }
 
     /**
-     * Returns the email address of the administrator to contact in case of
-     * error.
-     * 
-     * @return The email address.
-     */
-    public String getContactEmail() {
-        return contactEmail;
-    }
-
-    /**
      * Returns the description of the status.
-     * 
+     *
      * @return The description of the status.
      */
     public String getDescription() {
@@ -142,30 +100,12 @@ public class StatusInfo implements Serializable {
     }
 
     /**
-     * Returns the home URI to propose in case of error.
-     * 
-     * @return The home URI.
-     */
-    public String getHomeRef() {
-        return homeRef;
-    }
-
-    /**
      * Returns the short description of the status.
-     * 
+     *
      * @return The short description of the status.
      */
     public String getReasonPhrase() {
         return reasonPhrase;
-    }
-
-    /**
-     * Returns the URI of the specification describing the status.
-     * 
-     * @return The URI of the specification describing the status.
-     */
-    public String getUri() {
-        return this.uri;
     }
 
     /**
@@ -179,18 +119,8 @@ public class StatusInfo implements Serializable {
     }
 
     /**
-     * Sets the email address of the administrator to contact in case of error.
-     * 
-     * @param email
-     *            The email address.
-     */
-    public void setContactEmail(String email) {
-        this.contactEmail = email;
-    }
-
-    /**
      * Sets the description of the status.
-     * 
+     *
      * @param description
      *            The description of the status.
      */
@@ -199,18 +129,8 @@ public class StatusInfo implements Serializable {
     }
 
     /**
-     * Sets the home URI to propose in case of error.
-     * 
-     * @param homeRef
-     *            The home URI.
-     */
-    public void setHomeRef(String homeRef) {
-        this.homeRef = homeRef;
-    }
-
-    /**
      * Sets the short description of the status.
-     * 
+     *
      * @param reasonPhrase
      *            The short description of the status.
      */

--- a/modules/org.restlet/src/org/restlet/engine/converter/StatusInfoHtmlConverter.java
+++ b/modules/org.restlet/src/org/restlet/engine/converter/StatusInfoHtmlConverter.java
@@ -24,11 +24,6 @@
 
 package org.restlet.engine.converter;
 
-import java.io.IOException;
-import java.util.List;
-
-import org.restlet.Request;
-import org.restlet.Response;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import org.restlet.engine.application.StatusInfo;
@@ -38,6 +33,9 @@ import org.restlet.representation.Representation;
 import org.restlet.representation.StringRepresentation;
 import org.restlet.representation.Variant;
 import org.restlet.resource.Resource;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * Converter for the {@link StatusInfo} class.
@@ -53,6 +51,31 @@ public class StatusInfoHtmlConverter extends ConverterHelper {
     /** Variant with media type text/html. */
     private static final VariantInfo VARIANT_TEXT_HTML = new VariantInfo(
             MediaType.TEXT_HTML);
+
+    /** The email address of the administrator to contact in case of error. */
+    private String contactEmail;
+
+    /** The home URI to propose in case of error. */
+    private String homeRef;
+
+    /**
+     * Returns the email address of the administrator to contact in case of
+     * error.
+     *
+     * @return The email address.
+     */
+    public String getContactEmail() {
+        return contactEmail;
+    }
+
+    /**
+     * Returns the home URI to propose in case of error.
+     *
+     * @return The home URI.
+     */
+    public String getHomeRef() {
+        return homeRef;
+    }
 
     @Override
     public List<Class<?>> getObjectClasses(Variant source) {
@@ -72,7 +95,7 @@ public class StatusInfoHtmlConverter extends ConverterHelper {
      * @param status
      *            The status.
      * @return The status information.
-     * @see #getDefaultRepresentation(Status, Request, Response)
+     * @see #toHtml(org.restlet.engine.application.StatusInfo)
      */
     protected String getStatusLabel(StatusInfo status) {
         return (status.getReasonPhrase() != null) ? status.getReasonPhrase()
@@ -124,15 +147,36 @@ public class StatusInfoHtmlConverter extends ConverterHelper {
     }
 
     /**
+     * Sets the email address of the administrator to contact in case of error.
+     *
+     * @param email
+     *            The email address.
+     */
+    public void setContactEmail(String email) {
+        this.contactEmail = email;
+    }
+
+    /**
+     * Sets the home URI to propose in case of error.
+     *
+     * @param homeRef
+     *            The home URI.
+     */
+    public void setHomeRef(String homeRef) {
+        this.homeRef = homeRef;
+    }
+
+    /**
      * Returns a representation for the given status.<br>
      * In order to customize the default representation, this method can be
      * overridden.
      * 
-     * @param status
+     * @param statusInfo
      *            The status info to represent.
      * @return The representation of the given status.
      */
-    protected Representation toHtml(StatusInfo status) {
+    protected Representation toHtml(StatusInfo statusInfo) {
+        Status status = Status.valueOf(statusInfo.getCode());
         final StringBuilder sb = new StringBuilder();
         sb.append("<html>\n");
         sb.append("<head>\n");
@@ -141,11 +185,11 @@ public class StatusInfoHtmlConverter extends ConverterHelper {
         sb.append("<body style=\"font-family: sans-serif;\">\n");
 
         sb.append("<p style=\"font-size: 1.2em;font-weight: bold;margin: 1em 0px;\">");
-        sb.append(StringUtils.htmlEscape(getStatusLabel(status)));
+        sb.append(StringUtils.htmlEscape(getStatusLabel(statusInfo)));
         sb.append("</p>\n");
-        if (status.getDescription() != null) {
+        if (statusInfo.getDescription() != null) {
             sb.append("<p>");
-            sb.append(StringUtils.htmlEscape(status.getDescription()));
+            sb.append(StringUtils.htmlEscape(statusInfo.getDescription()));
             sb.append("</p>\n");
         }
 
@@ -153,15 +197,15 @@ public class StatusInfoHtmlConverter extends ConverterHelper {
         sb.append(status.getUri());
         sb.append("\">here</a>.<br>\n");
 
-        if (status.getContactEmail() != null) {
+        if (getContactEmail() != null) {
             sb.append("For further assistance, you can contact the <a href=\"mailto:");
-            sb.append(status.getContactEmail());
+            sb.append(getContactEmail());
             sb.append("\">administrator</a>.<br>\n");
         }
 
-        if (status.getHomeRef() != null) {
+        if (getHomeRef() != null) {
             sb.append("Please continue your visit at our <a href=\"");
-            sb.append(status.getHomeRef());
+            sb.append(getHomeRef());
             sb.append("\">home page</a>.\n");
         }
 


### PR DESCRIPTION
Easier to define `contactEmail` and `honeRef` for HTML view and clean up the status serialization.
