### PR TITLE
Update allowed methods when catching a 405

### DIFF
--- a/modules/org.restlet/src/org/restlet/resource/ServerResource.java
+++ b/modules/org.restlet/src/org/restlet/resource/ServerResource.java
@@ -265,6 +265,10 @@ public abstract class ServerResource extends Resource {
         getLogger().log(level, "Exception or error caught in server resource",
                 throwable);
 
+        if (status.equals(Status.CLIENT_ERROR_METHOD_NOT_ALLOWED)) {
+            updateAllowedMethods();
+        }
+
         if (getResponse() != null) {
             getResponse().setStatus(status);
             Representation errorEntity = getStatusService().toRepresentation(


### PR DESCRIPTION
It is possible for a `ServerResource` to explicitly throw an exception (e.g. `throw new ResourceException(405)`) that bypasses the `updateAllowedMethods()` call in `ServerResource.handle()` leaving the `Allow` header contents empty. This change just adds a second check in the default `doCatch(Throwable)` implementation.