### PR TITLE
Remove basePath from ResourceListing, add translation from ResourceListing to Definition

### DIFF
--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/SwaggerReader.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/SwaggerReader.java
@@ -188,7 +188,8 @@ public class SwaggerReader {
         LOGGER.log(Level.FINE, "Contract " + contract.getName() + " added.");
         definition.setContract(contract);
 
-        if (definition.getEndpoints().isEmpty()) {
+        if (definition.getEndpoints().isEmpty()
+                && basePath != null) {
             // TODO verify how to deal with API key auth + oauth
             Endpoint endpoint = new Endpoint(basePath);
             definition.getEndpoints().add(endpoint);
@@ -650,6 +651,24 @@ public class SwaggerReader {
                     e);
         }
     }
+    
+    /**
+     * Translates a Swagger Resource Listing to a Restlet definition.
+     * 
+     * @param listing
+     *            The Swagger resource listing.
+     * @return The Restlet definition.
+     * @throws org.restlet.ext.apispark.internal.conversion.TranslationException
+     */
+    public static Definition translate(ResourceListing listing) {
+        Definition definition = new Definition();
+        fillMainAttributes(definition, listing, null);
+
+        LOGGER.log(Level.FINE,
+                "Main attributes successfully retrieved from Swagger resource listing.");
+        return definition;
+    }
+            
 
     /**
      * Indicates if the given resource listing and list of API declarations

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/model/ResourceListing.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/model/ResourceListing.java
@@ -39,8 +39,6 @@ public class ResourceListing {
 
     private AuthorizationsDeclaration authorizations;
 
-    private String basePath;
-
     private ApiInfo info;
 
     private String swaggerVersion;
@@ -69,10 +67,6 @@ public class ResourceListing {
         return authorizations;
     }
 
-    public String getBasePath() {
-        return basePath;
-    }
-
     public ApiInfo getInfo() {
         return info;
     }
@@ -91,10 +85,6 @@ public class ResourceListing {
 
     public void setAuthorizations(AuthorizationsDeclaration authorizations) {
         this.authorizations = authorizations;
-    }
-
-    public void setBasePath(String basePath) {
-        this.basePath = basePath;
     }
 
     public void setInfo(ApiInfo info) {


### PR DESCRIPTION
Scope: 
- Remove basePath from ResourceListing (it should not be there). 
- Create a translation method to retrieve information from a ResourceListing