### PR TITLE
Fix NPE when importing Swagger 2.0 without responses (restlet/apispark#4075)

### DIFF
--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/raml/RamlUtils.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/raml/RamlUtils.java
@@ -27,7 +27,7 @@ package org.restlet.ext.apispark.internal.conversion.raml;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -152,7 +152,7 @@ public class RamlUtils {
                 extended[0] = typeExtended;
                 objectSchema.setExtends(extended);
             }
-            objectSchema.setProperties(new HashMap<String, JsonSchema>());
+            objectSchema.setProperties(new LinkedHashMap<String, JsonSchema>());
             for (Property property : properties) {
                 String type = property.getType();
 

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/SwaggerReader.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/SwaggerReader.java
@@ -687,21 +687,12 @@ public class SwaggerReader {
     private static void fillSections(Contract contract, ResourceListing listing) {
         for (ResourceListingApi api : listing.getApis()) {
             Section section = new Section();
-            String sectionName = computeSectionName(api.getPath());
+            String sectionName = SwaggerUtils.computeSectionName(api.getPath());
             section.setName(sectionName);
             section.setDescription(api.getDescription());
 
             contract.getSections().add(section);
         }
-    }
-
-    private static String computeSectionName(String apiDeclarationPath) {
-        String result = apiDeclarationPath;
-        if (result.startsWith("/")) {
-            result = result.substring(1);
-        }
-
-        return result.replaceAll("/", "_");
     }
 
     /**

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/SwaggerUtils.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/SwaggerUtils.java
@@ -26,7 +26,7 @@ package org.restlet.ext.apispark.internal.conversion.swagger.v1_2;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -79,7 +79,7 @@ public abstract class SwaggerUtils {
         }
 
         ResourceListing resourceListing;
-        Map<String, ApiDeclaration> apis = new HashMap<String, ApiDeclaration>();
+        Map<String, ApiDeclaration> apis = new LinkedHashMap<String, ApiDeclaration>();
         if (ImportUtils.isRemoteUrl(swaggerUrl)) {
             LOGGER.log(Level.FINE, "Reading file: " + swaggerUrl);
             resourceListing = ImportUtils.getAndDeserialize(swaggerUrl, userName, password, ResourceListing.class);
@@ -110,5 +110,20 @@ public abstract class SwaggerUtils {
             }
         }
         return SwaggerReader.translate(resourceListing, apis);
+    }
+
+    /**
+     * Computes a section name from the Resource Listing api's path
+     * 
+     * @param apiDeclarationPath
+     *            The path
+     */
+    public static String computeSectionName(String apiDeclarationPath) {
+        String result = apiDeclarationPath;
+        if (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+
+        return result.replaceAll("/", "_");
     }
 }

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/model/ApiDeclaration.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v1_2/model/ApiDeclaration.java
@@ -25,7 +25,7 @@
 package org.restlet.ext.apispark.internal.conversion.swagger.v1_2.model;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -81,7 +81,7 @@ public class ApiDeclaration {
 
     public Map<String, ModelDeclaration> getModels() {
         if (models == null) {
-            models = new HashMap<String, ModelDeclaration>();
+            models = new LinkedHashMap<String, ModelDeclaration>();
         }
         return models;
     }

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v2_0/Swagger2Reader.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v2_0/Swagger2Reader.java
@@ -471,28 +471,30 @@ public class Swagger2Reader {
             return;
         }
 
-        for (String key : swaggerOperation.getResponses().keySet()) {
-            Response swaggerResponse = swaggerOperation.getResponses().get(key);
-            org.restlet.ext.apispark.internal.model.Response response =
-                    new org.restlet.ext.apispark.internal.model.Response();
+        if (swaggerOperation.getResponses() != null) {
+            for (String key : swaggerOperation.getResponses().keySet()) {
+                Response swaggerResponse = swaggerOperation.getResponses().get(key);
+                org.restlet.ext.apispark.internal.model.Response response =
+                        new org.restlet.ext.apispark.internal.model.Response();
 
-            int statusCode;
-            try {
-                statusCode = Integer.parseInt(key);
-                response.setCode(statusCode);
-            } catch (Exception e) {
-                // TODO: what to do with "Default" responses ?
-                LOGGER.warning("Response " + key + " for operation " + swaggerOperation.getOperationId() +
-                        " could not be retrieved because its key is not a valid status code.");
-                continue;
+                int statusCode;
+                try {
+                    statusCode = Integer.parseInt(key);
+                    response.setCode(statusCode);
+                } catch (Exception e) {
+                    // TODO: what to do with "Default" responses ?
+                    LOGGER.warning("Response " + key + " for operation " + swaggerOperation.getOperationId() +
+                            " could not be retrieved because its key is not a valid status code.");
+                    continue;
+                }
+
+                response.setMessage(swaggerResponse.getDescription());
+                response.setName(ConversionUtils.generateResponseName(statusCode));
+
+                fillOutputPayload(swaggerResponse, response, swaggerOperation, contract, parameters);
+
+                operation.getResponses().add(response);
             }
-
-            response.setMessage(swaggerResponse.getDescription());
-            response.setName(ConversionUtils.generateResponseName(statusCode));
-
-            fillOutputPayload(swaggerResponse, response, swaggerOperation, contract, parameters);
-
-            operation.getResponses().add(response);
         }
     }
 

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/model/Endpoint.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/model/Endpoint.java
@@ -69,7 +69,7 @@ public class Endpoint {
                 port = Integer.parseInt(m.group(4));
             }
         } else {
-            throw new RuntimeException("url does not match URL pattern: " + url);
+            throw new RuntimeException(url + " does not match URL pattern");
         }
     }
 


### PR DESCRIPTION
Scope: 

- prevent NPE when a Swagger 2.0 with an operation not containing any response is translated

Bonus scope:

- enhance message when an invalid URL is passed to Endpoint's constructor `Endpoint(String url)`
- replace all __HashMap__ to __LinkedHashMap__ to preserve orders in our definition languages java beans