### PR TITLE
Properly detect Tomcat & Jetty connection aborted exceptions in Call.isBroken()

### DIFF
--- a/modules/org.restlet/src/org/restlet/engine/adapter/Call.java
+++ b/modules/org.restlet/src/org/restlet/engine/adapter/Call.java
@@ -52,13 +52,21 @@ public abstract class Call {
     public static boolean isBroken(Throwable exception) {
         boolean result = false;
 
-        if (exception.getMessage() != null) {
-            result = (exception.getMessage().indexOf("Broken pipe") != -1)
-                    || (exception
-                            .getMessage()
-                            .equals("An existing connection must have been closed by the remote party.") || (exception
-                            .getMessage()
-                            .equals("An open connection has been abandonned by your network stack.")));
+        // detect Tomcat and Jetty exceptions
+        if (exception instanceof IOException) {
+            String exceptionName = exception.getClass().getName();
+            result = (exceptionName.endsWith("ClientAbortException") ||
+                exceptionName.endsWith("jetty.io.EofException"));
+        }
+
+        // check for known exception messages
+        if (!result) {
+            String exceptionMessage = exception.getMessage();
+            if (exceptionMessage != null) {
+                result = (exceptionMessage.indexOf("Broken pipe") != -1) ||
+                    (exceptionMessage.equals("An existing connection must have been closed by the remote party.") ||
+                        (exceptionMessage.equals("An open connection has been abandonned by your network stack.")));
+            }
         }
 
         if (!result && exception.getCause() != null) {

--- a/modules/org.restlet/src/org/restlet/engine/adapter/ServerAdapter.java
+++ b/modules/org.restlet/src/org/restlet/engine/adapter/ServerAdapter.java
@@ -188,10 +188,8 @@ public class ServerAdapter extends Adapter {
         } catch (Throwable t) {
             // [ifndef gae]
             if (response.getHttpCall().isConnectionBroken(t)) {
-                getLogger()
-                        .log(Level.INFO,
-                                "The connection was broken. It was probably closed by the client.",
-                                t);
+                // output a single log line for this common case to avoid filling servers logs
+                getLogger().log(Level.INFO, "The connection was broken. It was probably closed by the client. Reason: " + t.getMessage());
             } else
             // [enddef]
             {


### PR DESCRIPTION
Fix Tomcat & Jetty HTTP client connection aborted exceptions detection to execute the correct code path in ServerAdapter.commit() when connection is broken 
(This one is the same as the previous #1097 pull request, but for the 2.3 branch) 