### PR TITLE
Fix responses in Swagger 2.0 (restlet/apispark#4134)

### DIFF
--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v2_0/Swagger2Reader.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v2_0/Swagger2Reader.java
@@ -488,7 +488,7 @@ public class Swagger2Reader {
                     continue;
                 }
 
-                response.setMessage(swaggerResponse.getDescription());
+                response.setDescription(swaggerResponse.getDescription());
                 response.setName(ConversionUtils.generateResponseName(statusCode));
 
                 fillOutputPayload(swaggerResponse, response, swaggerOperation, contract, parameters);

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v2_0/Swagger2Writer.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/conversion/swagger/v2_0/Swagger2Writer.java
@@ -330,10 +330,10 @@ public class Swagger2Writer {
             Response responseSwagger = new Response();
 
             // may be null
-            String message = response.getMessage();
-            responseSwagger.setDescription(message == null
+            String description = response.getDescription();
+            responseSwagger.setDescription(description == null
                     ? ConversionUtils.generateResponseName(response.getCode())
-                            : message); // required
+                            : description); // required
 
             // Response Schema
             if (response.getOutputPayLoad() != null

--- a/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/model/Response.java
+++ b/modules/org.restlet.ext.apispark/src/org/restlet/ext/apispark/internal/model/Response.java
@@ -48,7 +48,8 @@ public class Response {
     /** The list of Headers associated with this response. */
     private List<Header> headers = new ArrayList<>();
 
-    /** Status message of the response. */
+    /** Status message of the response, will be deleted as description is sufficient. */
+    @Deprecated
     private String message;
 
     /** Name of this response. */

--- a/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/Swagger2TestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/Swagger2TestCase.java
@@ -729,10 +729,10 @@ public class Swagger2TestCase extends RestletTestCase {
             assertNotNull(savedResponse);
             assertNotNull(translatedResponse);
 
-            assertEquals(savedResponse.getMessage(), translatedResponse.getMessage());
+            assertEquals(savedResponse.getDescription(), translatedResponse.getDescription());
 
             // both don't exist in Swagger => can't be retrieved
-            // assertEquals(savedResponse.getDescription(), translatedResponse.getDescription());
+            // assertEquals(savedResponse.getMessage(), translatedResponse.getMessage());
             // assertEquals(savedResponse.getName(), translatedResponse.getName());
 
             compareRwadefHeaders(savedResponse.getHeaders(), translatedResponse.getHeaders());

--- a/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/Swagger2TranslatorTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/Swagger2TranslatorTestCase.java
@@ -32,8 +32,8 @@ import java.util.Map;
 
 import org.restlet.data.ChallengeScheme;
 import org.restlet.data.MediaType;
-import org.restlet.ext.apispark.internal.conversion.swagger.v2_0.Swagger2Writer;
 import org.restlet.ext.apispark.internal.conversion.swagger.v2_0.Swagger2Reader;
+import org.restlet.ext.apispark.internal.conversion.swagger.v2_0.Swagger2Writer;
 import org.restlet.ext.apispark.internal.model.Contract;
 import org.restlet.ext.apispark.internal.model.Definition;
 import org.restlet.ext.apispark.internal.model.Endpoint;
@@ -307,7 +307,7 @@ public class Swagger2TranslatorTestCase extends Swagger2TestCase {
         com.wordnik.swagger.models.Response op1Response2 = path1Get
                 .getResponses().get("300");
         assertNotNull(op1Response2);
-        assertEquals("Error 300", op1Response2.getDescription());
+        assertEquals("Status 300", op1Response2.getDescription());
         assertTrue(op1Response2.getSchema() instanceof RefProperty);
         RefProperty op1Response2RefProperty = (RefProperty) op1Response2
                 .getSchema();

--- a/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/refImpl.rwadef
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/refImpl.rwadef
@@ -391,14 +391,12 @@
                 },
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid tag value",
-                "message": "Error 400",
                 "name": "Error 400"
               }
             ],
@@ -436,21 +434,18 @@
                 },
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid ID supplied",
-                "message": "Error 400",
                 "name": "Error 400"
               },
               {
                 "outputPayLoad": null,
                 "code": 404,
                 "description": "Pet not found",
-                "message": "Error 404",
                 "name": "Error 404"
               }
             ],
@@ -474,14 +469,12 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid pet value",
-                "message": "Error 400",
                 "name": "Error 400"
               }
             ],
@@ -511,14 +504,12 @@
                 },
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid tag value",
-                "message": "Error 400",
                 "name": "Error 400"
               }
             ],
@@ -545,14 +536,12 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 405,
                 "description": "Invalid input",
-                "message": "Error 405",
                 "name": "Error 405"
               }
             ],
@@ -598,14 +587,12 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 405,
                 "description": "Invalid input",
-                "message": "Error 405",
                 "name": "Error 405"
               }
             ],
@@ -635,28 +622,24 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid ID supplied",
-                "message": "Error 400",
                 "name": "Error 400"
               },
               {
                 "outputPayLoad": null,
                 "code": 404,
                 "description": "Pet not found",
-                "message": "Error 404",
                 "name": "Error 404"
               },
               {
                 "outputPayLoad": null,
                 "code": 405,
                 "description": "Validation exception",
-                "message": "Error 405",
                 "name": "Error 405"
               }
             ],
@@ -707,14 +690,12 @@
                 },
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid status value",
-                "message": "Error 400",
                 "name": "Error 400"
               }
             ],
@@ -749,7 +730,6 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               }
             ],
@@ -786,21 +766,18 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid ID supplied",
-                "message": "Error 400",
                 "name": "Error 400"
               },
               {
                 "outputPayLoad": null,
                 "code": 404,
                 "description": "Order not found",
-                "message": "Error 404",
                 "name": "Error 404"
               }
             ],
@@ -824,21 +801,18 @@
                 },
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid ID supplied",
-                "message": "Error 400",
                 "name": "Error 400"
               },
               {
                 "outputPayLoad": null,
                 "code": 404,
                 "description": "Order not found",
-                "message": "Error 404",
                 "name": "Error 404"
               }
             ],
@@ -879,14 +853,12 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid order",
-                "message": "Error 400",
                 "name": "Error 400"
               }
             ],
@@ -921,7 +893,6 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               }
             ],
@@ -956,7 +927,6 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               }
             ],
@@ -991,7 +961,6 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               }
             ],
@@ -1026,21 +995,18 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid username supplied",
-                "message": "Error 400",
                 "name": "Error 400"
               },
               {
                 "outputPayLoad": null,
                 "code": 404,
                 "description": "User not found",
-                "message": "Error 404",
                 "name": "Error 404"
               }
             ],
@@ -1061,21 +1027,18 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid username supplied",
-                "message": "Error 400",
                 "name": "Error 400"
               },
               {
                 "outputPayLoad": null,
                 "code": 404,
                 "description": "User not found",
-                "message": "Error 404",
                 "name": "Error 404"
               }
             ],
@@ -1099,21 +1062,18 @@
                 },
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid username supplied",
-                "message": "Error 400",
                 "name": "Error 400"
               },
               {
                 "outputPayLoad": null,
                 "code": 404,
                 "description": "User not found",
-                "message": "Error 404",
                 "name": "Error 404"
               }
             ],
@@ -1171,14 +1131,12 @@
                 },
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               },
               {
                 "outputPayLoad": null,
                 "code": 400,
                 "description": "Invalid username and password combination",
-                "message": "Error 400",
                 "name": "Error 400"
               }
             ],
@@ -1210,7 +1168,6 @@
                 "outputPayLoad": null,
                 "code": 200,
                 "description": "The request has succeeded",
-                "message": "Success",
                 "name": "Success"
               }
             ],

--- a/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/refImpl.swagger
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/refImpl.swagger
@@ -66,10 +66,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "405": {
-            "description": "Error 405"
+            "description": "Invalid input"
           }
         }
       },
@@ -97,16 +97,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid ID supplied"
           },
           "404": {
-            "description": "Error 404"
+            "description": "Pet not found"
           },
           "405": {
-            "description": "Error 405"
+            "description": "Validation exception"
           }
         }
       }
@@ -144,7 +144,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The request has succeeded",
             "schema": {
               "type": "array",
               "items": {
@@ -153,7 +153,7 @@
             }
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid status value"
           }
         }
       }
@@ -186,7 +186,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The request has succeeded",
             "schema": {
               "type": "array",
               "items": {
@@ -195,7 +195,7 @@
             }
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid tag value"
           }
         }
       }
@@ -217,7 +217,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           }
         }
       }
@@ -246,16 +246,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The request has succeeded",
             "schema": {
               "$ref": "#/definitions/Pet"
             }
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid ID supplied"
           },
           "404": {
-            "description": "Error 404"
+            "description": "Pet not found"
           }
         }
       },
@@ -284,10 +284,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "405": {
-            "description": "Error 405"
+            "description": "Invalid input"
           }
         }
       },
@@ -314,10 +314,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid pet value"
           }
         }
       },
@@ -355,7 +355,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The request has succeeded",
             "schema": {
               "type": "array",
               "items": {
@@ -364,7 +364,7 @@
             }
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid tag value"
           }
         }
       }
@@ -391,10 +391,10 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid order"
           }
         }
       }
@@ -420,16 +420,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The request has succeeded",
             "schema": {
               "$ref": "#/definitions/Order"
             }
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid ID supplied"
           },
           "404": {
-            "description": "Error 404"
+            "description": "Order not found"
           }
         }
       },
@@ -453,13 +453,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid ID supplied"
           },
           "404": {
-            "description": "Error 404"
+            "description": "Order not found"
           }
         }
       }
@@ -486,7 +486,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           }
         }
       }
@@ -516,7 +516,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           }
         }
       }
@@ -546,7 +546,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           }
         }
       }
@@ -581,13 +581,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The request has succeeded",
             "schema": {
               "type": "string"
             }
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid username and password combination"
           }
         }
       }
@@ -604,7 +604,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           }
         }
       }
@@ -630,16 +630,16 @@
         ],
         "responses": {
           "200": {
-            "description": "Success",
+            "description": "The request has succeeded",
             "schema": {
               "$ref": "#/definitions/User"
             }
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid username supplied"
           },
           "404": {
-            "description": "Error 404"
+            "description": "User not found"
           }
         }
       },
@@ -671,13 +671,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid username supplied"
           },
           "404": {
-            "description": "Error 404"
+            "description": "User not found"
           }
         }
       },
@@ -701,13 +701,13 @@
         ],
         "responses": {
           "200": {
-            "description": "Success"
+            "description": "The request has succeeded"
           },
           "400": {
-            "description": "Error 400"
+            "description": "Invalid username supplied"
           },
           "404": {
-            "description": "Error 404"
+            "description": "User not found"
           }
         }
       }


### PR DESCRIPTION
Scope: 

- use RWADef Response's `description` attribute (instead of message) to fill in Swagger 2.0 Response's `description` attribute
- deprecate RWADef Response's `message` attribute as `description` is sufficient
- update tests