### PR TITLE
Fixed compilation on Java 8

### DIFF
--- a/modules/org.restlet/src/com/google/gwt/emul/java/util/concurrent/ConcurrentHashMap.java
+++ b/modules/org.restlet/src/com/google/gwt/emul/java/util/concurrent/ConcurrentHashMap.java
@@ -37,10 +37,13 @@ public class ConcurrentHashMap<K, V> extends TreeMap<K, V> implements
     /** */
     private static final long serialVersionUID = 1L;
 
-    public void putIfAbsent(K key, V value) {
+    public V putIfAbsent(K key, V value) {
         if (!containsKey(key)) {
-            put(key, value);
+            return put(key, value);
+        } else {
+            return get(key);
         }
+
     }
 
     public boolean remove(Object key, Object value) {

--- a/modules/org.restlet/src/com/google/gwt/emul/java/util/concurrent/ConcurrentMap.java
+++ b/modules/org.restlet/src/com/google/gwt/emul/java/util/concurrent/ConcurrentMap.java
@@ -42,7 +42,7 @@ public interface ConcurrentMap<K, V> extends Map<K, V> {
      * @param value
      *            The value
      */
-    void putIfAbsent(K key, V value);
+    V putIfAbsent(K key, V value);
 
     /**
      * Remove entry for key only if currently mapped to given value.


### PR DESCRIPTION
Aligned the `ConcurrentMap` interface with the JDK one. The difference was preventing the framework from compiling under JDK 8.