### PR TITLE
Added best-effort support for inline schemas in Swagger definitions

### DIFF
--- a/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/refImpl.rwadef
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/apispark/conversion/swagger/v2_0/refImpl.rwadef
@@ -357,6 +357,12 @@
           }
         ],
         "raw": false
+      },
+      {
+      	"name": "anonymousRepresentation6"
+      },
+      {
+      	"name": "anonymousRepresentation7"
       }
     ],
     "resources": [


### PR DESCRIPTION
This PR adds support for inline schemas describing body parameters of operations in Swagger definitions. These schemas are imported as representation, just like schemas found in the `definitions` part of Swagger definitions. Inline schemas for responses cannot be supported right now because of a limitation of `swagger-core` (see [this issue](https://github.com/swagger-api/swagger-core/issues/1306)).