### PR TITLE
Fix Issue#1130: Method value caching broken

### DIFF
--- a/modules/org.restlet.test/src/org/restlet/test/data/MethodTestCase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/data/MethodTestCase.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2005-2014 Restlet
+ * 
+ * The contents of this file are subject to the terms of one of the following
+ * open source licenses: Apache 2.0 or or EPL 1.0 (the "Licenses"). You can
+ * select the license that you prefer but you may not use this file except in
+ * compliance with one of these Licenses.
+ * 
+ * You can obtain a copy of the Apache 2.0 license at
+ * http://www.opensource.org/licenses/apache-2.0
+ * 
+ * You can obtain a copy of the EPL 1.0 license at
+ * http://www.opensource.org/licenses/eclipse-1.0
+ * 
+ * See the Licenses for the specific language governing permissions and
+ * limitations under the Licenses.
+ * 
+ * Alternatively, you can obtain a royalty free commercial license with less
+ * limitations, transferable or non-transferable, directly at
+ * http://restlet.com/products/restlet-framework
+ * 
+ * Restlet is a registered trademark of Restlet S.A.S.
+ */
+
+package org.restlet.test.data;
+
+import org.restlet.data.Method;
+
+import junit.framework.TestCase;
+
+/**
+ * Test {@link org.restlet.data.Method}.
+ * <p>
+ * Note: this test purposefully does *not* extends RestletTestCase. The
+ * regression previously present in Restlet
+ * (desribed in https://github.com/restlet/restlet-framework-java/issues/1130) depends on
+ * class initialization order and vanishes when the Restlet/Engine class is
+ * initialized before the class Method.
+ * 
+ * @author Andreas Wundsam
+ */
+public class MethodTestCase extends TestCase {
+
+	/**
+	 * validate that Method caching works, i.e., the value returned by
+	 * Method.valueOf("GET") is the cached constant Method.GET
+	 */
+	public void testCaching() {
+		assertTrue("Method.valueOf('GET') should return cached constant Method.GET ",
+				Method.GET == Method.valueOf("GET"));
+	}
+
+}

--- a/modules/org.restlet/src/org/restlet/data/Method.java
+++ b/modules/org.restlet/src/org/restlet/data/Method.java
@@ -237,7 +237,7 @@ public final class Method implements Comparable<Method> {
     /** The URI of the specification describing the method. */
     private volatile String uri;
 
-    {
+    static {
         // Let the engine register all methods (the default ones and the ones to
         // be discovered) as soon as the Method class is loaded or at least
         // used.


### PR DESCRIPTION
Fixes issue #1130 .

This commit fixes a bug in Method.java where the class initialization
order would not work out and no Methods would be cached (i.e., valueOf
would return a new instance of Method every time).

This would happen if the class Method was initialized *before*
Engine.getEngine() was called (which would trigger the registration
in HttpProtocolHelper.registerMethods).

The root cause is the initialization block in Method.java#L.240. This
block is supposed to be called after the class constants (GET, etc.)
have been initialized and assigned. But it is missing the static {}
keyword, so it is not actually a class initialization block, but an
object initialization block. It is thus called when the first constant
instance is initialized, before the constants are assigned. This means
that the constants read by HttpProtocolHelper.registerMethods are still
null, and no Methods get registered.

This commit also contains a unit test that would previously fail.