### PR TITLE
Duplicate subexpressions in ParameterList.java

### DIFF
--- a/modules/org.restlet.ext.jaxrs/src/org/restlet/ext/jaxrs/internal/wrappers/params/ParameterList.java
+++ b/modules/org.restlet.ext.jaxrs/src/org/restlet/ext/jaxrs/internal/wrappers/params/ParameterList.java
@@ -424,8 +424,7 @@ public class ParameterList {
             } else if (!(e instanceof NoSuchMethodException)
                     && !(e instanceof IllegalAccessException)
                     && !(e instanceof InvocationTargetException)
-                    && !(e instanceof InstantiationException)
-                    && !(e instanceof NoSuchMethodException)) {
+                    && !(e instanceof InstantiationException)) {
                 throw ConvertParameterException
                         .object(this.convertTo, value, e);
             }


### PR DESCRIPTION
`!(e instanceof NoSuchMethodException)` is duplicated.