### PR TITLE
Match token type case insensitively to broaden supported platforms

### DIFF
--- a/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/ProtectedClientResource.java
+++ b/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/ProtectedClientResource.java
@@ -128,7 +128,7 @@ public class ProtectedClientResource extends ClientResource implements
             throw new ResourceException(Status.CLIENT_ERROR_UNAUTHORIZED,
                     "Token not found");
         }
-        if (token.getTokenType().equals(TOKEN_TYPE_BEARER)) {
+        if (TOKEN_TYPE_BEARER.equalsIgnoreCase(token.getTokenType())) {
             if (isUseBodyMethod()) {
                 Representation entity = request.getEntity();
                 if (entity != null

--- a/modules/org.restlet.test/src/org/restlet/test/ext/oauth/OAuthTestBase.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/oauth/OAuthTestBase.java
@@ -91,6 +91,42 @@ public class OAuthTestBase {
             return false;
         }
     };
+    
+    public static Token SPRING_STUB_TOKEN = new ServerToken() {
+
+        public String getAccessToken() {
+            return STUB_ACCESS_TOKEN;
+        }
+
+        public String getTokenType() {
+        	//Spring returns bearer in lower case
+            return "bearer";
+        }
+
+        public int getExpirePeriod() {
+            return 3600;
+        }
+
+        public String getRefreshToken() {
+            return STUB_REFRESH_TOKEN;
+        }
+
+        public String[] getScope() {
+            return new String[] { "a", "b" };
+        }
+
+        public String getUsername() {
+            return STUB_USERNAME;
+        }
+
+        public String getClientId() {
+            return STUB_CLIENT_ID;
+        }
+
+        public boolean isExpired() {
+            return false;
+        }
+    };
 
     public static final Client STUB_CLIENT = new Client() {
 

--- a/modules/org.restlet.test/src/org/restlet/test/ext/oauth/ProtectedClientResourceTest.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/oauth/ProtectedClientResourceTest.java
@@ -152,4 +152,14 @@ public class ProtectedClientResourceTest extends OAuthTestBase {
         resource.addQueryParameter("foo", "bar");
         resource.get();
     }
+    
+    //Test compatibility with modules that don't match token type case
+    @Test
+    public void testCase4() {
+        ProtectedClientResource resource = new ProtectedClientResource(
+                new Reference(baseURI, "/app/resource1"));
+        resource.setToken(SPRING_STUB_TOKEN);
+        resource.setUseBodyMethod(false);
+        resource.get();
+    }
 }


### PR DESCRIPTION
The ProtectedClientResource previously used "equals" to compare the string token type read from an authorization server to the bearer type constant within the Restlet OAuth extension, which is set to "Bearer". Some OAuth 2.0 implementations return this value in a different case (ex: "bearer"), and the difference in case prevented use of the token. By changing the ProtectedClientResource to match this value in a case insensitive way, more OAuth implementations, including spring, can be supported natively