### PR TITLE
Add Overload to OAuthParameters.toReference which Accepts an Existing Reference

### DIFF
--- a/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/OAuthParameters.java
+++ b/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/OAuthParameters.java
@@ -118,6 +118,23 @@ public class OAuthParameters implements OAuthResourceDefs {
         reference.setQuery(query);
         return reference;
     }
+    
+    public Reference toReference(Reference ref) {
+        String query;
+        
+        try {
+            query = form.encode();
+        } catch (IOException ex) {
+            Logger.getLogger(OAuthParameters.class.getName()).log(Level.SEVERE,
+                    null, ex);
+            throw new ResourceException(ex);
+        }
+        
+        Reference reference = new Reference(ref);
+        reference.setQuery(query);
+        
+        return reference;
+    }
 
     public Representation toRepresentation() {
         return form.getWebRepresentation();

--- a/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/OAuthParameters.java
+++ b/modules/org.restlet.ext.oauth/src/org/restlet/ext/oauth/OAuthParameters.java
@@ -29,6 +29,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.restlet.data.Form;
+import org.restlet.data.Parameter;
 import org.restlet.data.Reference;
 import org.restlet.ext.oauth.internal.Scopes;
 import org.restlet.representation.Representation;
@@ -120,18 +121,12 @@ public class OAuthParameters implements OAuthResourceDefs {
     }
     
     public Reference toReference(Reference ref) {
-        String query;
+    	Reference reference = new Reference(ref);
         
-        try {
-            query = form.encode();
-        } catch (IOException ex) {
-            Logger.getLogger(OAuthParameters.class.getName()).log(Level.SEVERE,
-                    null, ex);
-            throw new ResourceException(ex);
+        //Add each parameter to avoid overwriting existing parameters
+        for(Parameter param : form){
+        	reference.addQueryParameter(param);
         }
-        
-        Reference reference = new Reference(ref);
-        reference.setQuery(query);
         
         return reference;
     }

--- a/modules/org.restlet.test/src/org/restlet/test/ext/oauth/OAuthParametersTest.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/oauth/OAuthParametersTest.java
@@ -64,4 +64,15 @@ public class OAuthParametersTest {
         assertEquals("val2", form.getFirstValue("bar"));
         assertEquals("val3", form.getFirstValue("buz"));
     }
+    
+    @Test
+    public void testToReferenceFromReference() {
+    	Reference originalReference = new Reference("http://localhost/test");
+    	
+        Reference reference = parameters.toReference(originalReference);
+        Form form = reference.getQueryAsForm();
+        assertEquals("val1", form.getFirstValue("foo"));
+        assertEquals("val2", form.getFirstValue("bar"));
+        assertEquals("val3", form.getFirstValue("buz"));
+    }
 }

--- a/modules/org.restlet.test/src/org/restlet/test/ext/oauth/OAuthParametersTest.java
+++ b/modules/org.restlet.test/src/org/restlet/test/ext/oauth/OAuthParametersTest.java
@@ -67,10 +67,11 @@ public class OAuthParametersTest {
     
     @Test
     public void testToReferenceFromReference() {
-    	Reference originalReference = new Reference("http://localhost/test");
+    	Reference originalReference = new Reference("http://localhost/test?existing=thing");
     	
         Reference reference = parameters.toReference(originalReference);
         Form form = reference.getQueryAsForm();
+        assertEquals("thing", form.getFirstValue("existing"));
         assertEquals("val1", form.getFirstValue("foo"));
         assertEquals("val2", form.getFirstValue("bar"));
         assertEquals("val3", form.getFirstValue("buz"));


### PR DESCRIPTION
Prevent unpacking and repacking of reference instances when adding client query information from OAuthParameters by providing a call to apply the query to an existing reference.

When using the existing APIs, I found that a common pattern emerged where a Reference was present, but had to be serialized and deserialized to and from a String in order to add OAuth query parameters. If the OAuthParameters instance offered a toReference call which took a reference object, this pattern could be simplified for clients. 
