### PR TITLE
Fix NPE if queue returns null in PipeStream

### DIFF
--- a/modules/org.restlet/src/org/restlet/engine/io/PipeStream.java
+++ b/modules/org.restlet/src/org/restlet/engine/io/PipeStream.java
@@ -69,12 +69,12 @@ public class PipeStream {
 
                     final Integer value = queue.poll(QUEUE_TIMEOUT,
                             TimeUnit.SECONDS);
-                    this.endReached = (value == -1);
 
                     if (value == null) {
                         throw new IOException(
                                 "Timeout while reading from the queue-based input stream");
                     } else {
+                        this.endReached = (value == -1);
                         return value.intValue();
                     }
                 } catch (InterruptedException ie) {


### PR DESCRIPTION
If value returned from queue is null, a NPE is thrown before the IOException timeout block can be reached.