### PR TITLE
Fix 404 links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ http://restlet.com
 
 To learn more about Restlet Framework, please have a look at the following resources:
 
-* [User Guide](http://restlet.com/technical-resources/restlet-framework/guide/2.3)
-* [Tutorials](http://restlet.com/technical-resources/restlet-framework/tutorials/2.3)
-* [JavaDocs](http://restlet.com/technical-resources/restlet-framework/javadocs/3.0)
-* [Change Log](http://restlet.com/technical-resources/restlet-framework/misc/3.0/changes)
-* [Download](http://restlet.com/downloads/current/)
+* [User Guide](https://restlet.com/open-source/documentation/user-guide/2.3)
+* [Tutorials](https://restlet.com/open-source/documentation/tutorials/2.3)
+* [JavaDocs](https://restlet.com/open-source/documentation/javadocs/2.3)
+* [Change Log](https://restlet.com/open-source/documentation/3.0/changelog)
+* [Download](https://restlet.com/open-source/downloads/current/)
 * [Issue Tracker](https://github.com/restlet/restlet-framework-java/issues)
 * [Mailing List](https://groups.google.com/a/restlet.org/forum/#!forum/framework-discuss)
 * [Stack Overflow](http://stackoverflow.com/questions/tagged/restlet)


### PR DESCRIPTION
Even though some links seemed to be redirected to a new page under restlet.com/open-source/, others like javadocs and tutorials are giving 404. This PR updates the links to avoid redirects or 404's.

Thanks
Bruno