### PR TITLE
Allow parsing of double values like "2.0" or "4.0" being received in the Retry-After header.

### DIFF
--- a/modules/org.restlet/src/org/restlet/engine/header/HeaderUtils.java
+++ b/modules/org.restlet/src/org/restlet/engine/header/HeaderUtils.java
@@ -768,7 +768,7 @@ public class HeaderUtils {
                     if (retryAfter == null) {
                         // The date might be expressed as a number of seconds
                         try {
-                            int retryAfterSecs = Integer.parseInt(header.getValue());
+                            int retryAfterSecs = (int) Double.parseDouble(header.getValue());
                             java.util.Calendar calendar = java.util.Calendar.getInstance();
                             calendar.add(java.util.Calendar.SECOND, retryAfterSecs);
                             retryAfter = calendar.getTime();


### PR DESCRIPTION
We are using Restlet version 2.4.1 to communicate with 3rd party API's like Shopify and certain API's are returning Retry-After headers as doubles instead of integers.  This is causing Restlet to throw a NumberFormatException like below and is not processing the message correctly.

```
Error during Retry-After header parsing. Header: 4.0
LOGGER NAME
org.restlet
THREAD NAME
RecordProcessor-0001

ERROR KIND
java.lang.NumberFormatException
ERROR MESSAGE
For input string: "4.0"
ERROR STACK
java.lang.NumberFormatException: For input string: "4.0"
at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
at java.base/java.lang.Integer.parseInt(Integer.java:652)
at java.base/java.lang.Integer.parseInt(Integer.java:770)
at org.restlet.engine.header.HeaderUtils.copyResponseTransportHeaders(HeaderUtils.java:756)
at org.restlet.engine.adapter.ClientAdapter.readResponseHeaders(ClientAdapter.java:128)
at org.restlet.engine.adapter.ClientAdapter.updateResponse(ClientAdapter.java:190)
at org.restlet.engine.adapter.ClientAdapter.commit(ClientAdapter.java:105)
at org.restlet.engine.adapter.HttpClientHelper.handle(HttpClientHelper.java:119)
at org.restlet.Client.handle(Client.java:153)
at org.restlet.routing.Filter.doHandle(Filter.java:150)
at org.restlet.routing.Filter.handle(Filter.java:197)
at org.restlet.resource.ClientResource.handle(ClientResource.java:1122)
at com.unific.shopify.clients.rest.ShopifyClientResource.handle(ShopifyClientResource.java:38)
at org.restlet.resource.ClientResource.handleOutbound(ClientResource.java:1208)
at org.restlet.engine.resource.ClientInvocationHandler.invoke(ClientInvocationHandler.java:263)
at com.sun.proxy.$Proxy219.createPriceRule(Unknown Source)
at com.unific.shopify.clients.rest.PriceRuleRestClient.createPriceRule(PriceRuleRestClient.java:66)
at com.unific.coupon.store.ShopifyCouponGenerator.generatePriceRule(ShopifyCouponGenerator.java:123)
at com.unific.coupon.store.ShopifyCouponGenerator.generate(ShopifyCouponGenerator.java:88)
at com.unific.coupon.store.CouponGeneratorRegistry.generate(CouponGeneratorRegistry.java:69)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:564)
at com.unific.featureflag.FeatureProxyFactoryBean.lambda$getObject$0(FeatureProxyFactoryBean.java:66)
at com.sun.proxy.$Proxy160.generate(Unknown Source)
at com.unific.coupon.CouponService.process(CouponService.java:83)
at com.unific.coupon.DiscountCodeRequestStreamRecordProcessor.process(DiscountCodeRequestStreamRecordProcessor.java:33)
at com.unific.coupon.DiscountCodeRequestStreamRecordProcessor.process(DiscountCodeRequestStreamRecordProcessor.java:13)
at com.unific.aws.kinesis.client.KinesisRecordProcessor.processRecords(KinesisRecordProcessor.java:102)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.ProcessTask.callProcessRecords(ProcessTask.java:221)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.ProcessTask.call(ProcessTask.java:176)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.MetricsCollectingTaskDecorator.call(MetricsCollectingTaskDecorator.java:49)
at com.amazonaws.services.kinesis.clientlibrary.lib.worker.MetricsCollectingTaskDecorator.call(MetricsCollectingTaskDecorator.java:24)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1135)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
at java.base/java.lang.Thread.run(Thread.java:844)
```