### PR TITLE
ResourceException: avoid NotSerializableException

### DIFF
--- a/modules/org.restlet/src/main/java/org/restlet/resource/ResourceException.java
+++ b/modules/org.restlet/src/main/java/org/restlet/resource/ResourceException.java
@@ -30,7 +30,12 @@ import org.restlet.data.Status;
 
 /**
  * Encapsulates a response status and the optional cause as a checked exception.
- * 
+ * <p>
+ * Note that this class must implement java.io.Serializable, because it extends
+ * RuntimeException. To avoid warnings, it provides a serialVersionUID and has
+ * its non-serializable fields marked transient. The default serialization thus
+ * obtained is minimal, and may not be what the user expects.
+ *
  * @author Jerome Louvel
  */
 public class ResourceException extends RuntimeException {

--- a/modules/org.restlet/src/main/java/org/restlet/resource/ResourceException.java
+++ b/modules/org.restlet/src/main/java/org/restlet/resource/ResourceException.java
@@ -38,13 +38,13 @@ public class ResourceException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
     /** The status associated to this exception. */
-    private final Status status;
+    private final transient Status status;
 
     /** The request associated to this exception. Could be null. */
-    private final Request request;
+    private final transient Request request;
 
     /** The response associated to this exception. Could be null.  */
-    private final Response response;
+    private final transient Response response;
 
     /**
      * Constructor.


### PR DESCRIPTION
- non-serializable internal attributes (status, request, and message) marked as transient
- this is to allow ResourceException to be serialized, passing over the message and stack-trace (which is typically all that is needed to show the error or print it in the log)
- fixes issue #1402