### PR TITLE
Ensure current application not set when there is no previous current application.

### DIFF
--- a/modules/org.restlet/src/main/java/org/restlet/engine/application/ApplicationHelper.java
+++ b/modules/org.restlet/src/main/java/org/restlet/engine/application/ApplicationHelper.java
@@ -77,7 +77,9 @@ public class ApplicationHelper extends CompositeHelper<Application> {
             super.handle(request, response);
         } finally {
             // restaure the current application
-            Application.setCurrent(current);
+            if (current != null) {
+                Application.setCurrent(current);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes issue #1317 in 2.4 - applies #1318 (merged in 2.3) to 2.4.

_We have been running this patch with restlet 2.4.3 for the last 2 years._