### PR TITLE
Remove FileUpload extension variant using Servlet API

### DIFF
--- a/modules/org.restlet.example/src/main/java/org/restlet/example/book/restlet/ch07/sec1/sub5/MailServerApplication.java
+++ b/modules/org.restlet.example/src/main/java/org/restlet/example/book/restlet/ch07/sec1/sub5/MailServerApplication.java
@@ -26,6 +26,7 @@ package org.restlet.example.book.restlet.ch07.sec1.sub5;
 
 import org.restlet.Application;
 import org.restlet.Component;
+import org.restlet.Context;
 import org.restlet.Restlet;
 import org.restlet.data.Protocol;
 import org.restlet.routing.Router;
@@ -49,6 +50,13 @@ public class MailServerApplication extends Application {
         mailServer.getDefaultHost().attach(new MailServerApplication());
         mailServer.start();
     }
+    
+    public MailServerApplication() {
+	}
+    
+    public MailServerApplication(Context parentContext) {
+		super(parentContext);
+	}
 
     /**
      * Creates a root Router to dispatch call to server resources.

--- a/modules/org.restlet.ext.fileupload/pom.xml
+++ b/modules/org.restlet.ext.fileupload/pom.xml
@@ -15,6 +15,12 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<version>${lib-servlet-version}</version>
+				<scope>provided</scope>
+		</dependency>
+		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
 			<version>${lib-fileupload-version}</version>

--- a/modules/org.restlet.ext.fileupload/pom.xml
+++ b/modules/org.restlet.ext.fileupload/pom.xml
@@ -15,12 +15,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>${lib-servlet-version}</version>
-				<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
 			<version>${lib-fileupload-version}</version>

--- a/modules/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RepresentationContext.java
+++ b/modules/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RepresentationContext.java
@@ -27,7 +27,7 @@ package org.restlet.ext.fileupload;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.fileupload.RequestContext;
+import org.apache.commons.fileupload.UploadContext;
 import org.restlet.representation.Representation;
 
 /**
@@ -36,7 +36,7 @@ import org.restlet.representation.Representation;
  * 
  * @author Jerome Louvel
  */
-public class RepresentationContext implements RequestContext {
+public class RepresentationContext implements UploadContext  {
 
     /** The representation to adapt. */
     private volatile Representation multipartForm;
@@ -51,11 +51,12 @@ public class RepresentationContext implements RequestContext {
         this.multipartForm = multipartForm;
     }
 
-    /**
-     * Returns the character encoding for the form.
-     * 
-     * @return The character encoding for the form.
-     */
+	@Override
+	public long contentLength() {
+        return this.multipartForm.getSize();
+	}
+
+	@Override
     public String getCharacterEncoding() {
         if (this.multipartForm.getCharacterSet() != null) {
             return this.multipartForm.getCharacterSet().getName();
@@ -64,20 +65,12 @@ public class RepresentationContext implements RequestContext {
         return null;
     }
 
-    /**
-     * Returns the content length of the form.
-     * 
-     * @return The content length of the form.
-     */
+	@Override
     public int getContentLength() {
-        return (int) this.multipartForm.getSize();
+        return (int) contentLength();
     }
 
-    /**
-     * Returns the content type of the form.
-     * 
-     * @return The content type of the form.
-     */
+	@Override
     public String getContentType() {
         if (this.multipartForm.getMediaType() != null) {
             return this.multipartForm.getMediaType().toString();
@@ -86,11 +79,7 @@ public class RepresentationContext implements RequestContext {
         return null;
     }
 
-    /**
-     * Returns the input stream.
-     * 
-     * @return The input stream.
-     */
+	@Override
     public InputStream getInputStream() throws IOException {
         return this.multipartForm.getStream();
     }

--- a/modules/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RestletFileUpload.java
+++ b/modules/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RestletFileUpload.java
@@ -31,8 +31,10 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileItemFactory;
 import org.apache.commons.fileupload.FileItemIterator;
 import org.apache.commons.fileupload.FileUpload;
+import org.apache.commons.fileupload.FileUploadBase;
 import org.apache.commons.fileupload.FileUploadException;
 import org.restlet.Request;
+import org.restlet.data.Method;
 import org.restlet.representation.Representation;
 
 /**
@@ -42,104 +44,102 @@ import org.restlet.representation.Representation;
  * list of FileItems associated with a given HTML widget.<br>
  * <br>
  * How the data for individual parts is stored is determined by the factory used
- * to create them; a given part may be in memory, on disk, or somewhere else.<br>
+ * to create them; a given part may be in memory, on disk, or somewhere
+ * else.<br>
  * <br>
  * In addition, it is possible to use <a
- * href="https://commons.apache.org/proper/commons-fileupload/streaming.html> FileUpload's
- * streaming API</a> to prevent the intermediary storage step. For this, use the
+ * href="https://commons.apache.org/proper/commons-fileupload/streaming.html>
+ * FileUpload's streaming API</a> to prevent the intermediary storage step. For
+ * this, use the
  * {@link #getItemIterator(org.apache.commons.fileupload.RequestContext)}
  * method.
  * 
  * @author Jerome Louvel
  */
-public class RestletFileUpload extends
-// [ifndef gae,jee] line
-        FileUpload
-// [ifdef gae,jee] line uncomment
-// org.apache.commons.fileupload.servlet.ServletFileUpload
-{
-    /**
-     * Constructs an uninitialized instance of this class. A factory must be
-     * configured, using <code>setFileItemFactory()</code>, before attempting to
-     * parse request entity.
-     * 
-     * @see RestletFileUpload#RestletFileUpload(FileItemFactory)
-     */
-    public RestletFileUpload() {
-        super();
-    }
+public class RestletFileUpload extends FileUpload {
+	/**
+	 * Determines if the request has multipart content.
+	 *
+	 * @param request The request to be assessed.
+	 *
+	 * @return True if the request is multipart.
+	 */
+	public static final boolean isMultipartContent(Request request) {
+		if (request.getMethod().equals(Method.POST)) {
+			return FileUploadBase.isMultipartContent(new RepresentationContext(request.getEntity()));
+		} else {
+			return false;
+		}
+	}
 
-    /**
-     * Constructs an instance of this class which uses the supplied factory to
-     * create <code>FileItem</code> instances.
-     * 
-     * @see RestletFileUpload#RestletFileUpload()
-     */
-    public RestletFileUpload(FileItemFactory fileItemFactory) {
-        super(fileItemFactory);
-    }
+	/**
+	 * Constructs an uninitialized instance of this class. A factory must be
+	 * configured, using <code>setFileItemFactory()</code>, before attempting to
+	 * parse request entity.
+	 * 
+	 * @see RestletFileUpload#RestletFileUpload(FileItemFactory)
+	 */
+	public RestletFileUpload() {
+		super();
+	}
 
-    /**
-     * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
-     * compliant <code>multipart/form-data</code> input representation. Note
-     * that this will not result in the writing of the parts on the disk but
-     * will instead allow you to use stream access.
-     * 
-     * @param multipartForm
-     *            The input representation.
-     * @return An iterator to instances of FileItemStream parsed from the
-     *         request.
-     * @throws FileUploadException
-     * @throws IOException
-     * @see <a
-     *      href="http://commons.apache.org/fileupload/streaming.html">FileUpload
-     *      Streaming API</a>
-     */
-    public FileItemIterator getItemIterator(Representation multipartForm)
-            throws FileUploadException, IOException {
-        return getItemIterator(new RepresentationContext(multipartForm));
-    }
+	/**
+	 * Constructs an instance of this class which uses the supplied factory to
+	 * create <code>FileItem</code> instances.
+	 * 
+	 * @see RestletFileUpload#RestletFileUpload()
+	 */
+	public RestletFileUpload(FileItemFactory fileItemFactory) {
+		super(fileItemFactory);
+	}
 
-    // [ifndef gae] method
-    /**
-     * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
-     * compliant <code>multipart/form-data</code> input representation. Note
-     * that this will result in the writing of the parts on the disk.
-     * 
-     * @param multipartForm
-     *            The multipart representation to be parsed.
-     * @return A list of <code>FileItem</code> instances parsed, in the order
-     *         that they were transmitted.
-     * @throws FileUploadException
-     *             if there are problems reading/parsing the request or storing
-     *             files.
-     */
-    public List<FileItem> parseRepresentation(Representation multipartForm)
-            throws FileUploadException {
-        return parseRequest(new RepresentationContext(multipartForm));
-    }
+	/**
+	 * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
+	 * compliant <code>multipart/form-data</code> input representation. Note that
+	 * this will not result in the writing of the parts on the disk but will instead
+	 * allow you to use stream access.
+	 * 
+	 * @param multipartForm The input representation.
+	 * @return An iterator to instances of FileItemStream parsed from the request.
+	 * @throws FileUploadException
+	 * @throws IOException
+	 * @see <a href="http://commons.apache.org/fileupload/streaming.html">FileUpload
+	 *      Streaming API</a>
+	 */
+	public FileItemIterator getItemIterator(Representation multipartForm) throws FileUploadException, IOException {
+		return getItemIterator(new RepresentationContext(multipartForm));
+	}
 
-    // [ifndef gae] method
-    /**
-     * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
-     * compliant <code>multipart/form-data</code> input representation. Note
-     * that this will result in the writing of the parts on the disk.
-     * 
-     * @param request
-     *            The request containing the entity to be parsed.
-     * @return A list of <code>FileItem</code> instances parsed, in the order
-     *         that they were transmitted.
-     * @throws FileUploadException
-     *             if there are problems reading/parsing the request or storing
-     *             files.
-     */
-    public List<FileItem> parseRequest(Request request)
-            throws FileUploadException {
-        // [ifndef jee] instruction
-        return parseRequest(new RepresentationContext(request.getEntity()));
-        // [ifdef jee] instruction uncomment
-        // return
-        // parseRequest(org.restlet.ext.servlet.ServletUtils.getRequest(request));
-    }
+	// [ifndef gae] method
+	/**
+	 * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
+	 * compliant <code>multipart/form-data</code> input representation. Note that
+	 * this will result in the writing of the parts on the disk.
+	 * 
+	 * @param multipartForm The multipart representation to be parsed.
+	 * @return A list of <code>FileItem</code> instances parsed, in the order that
+	 *         they were transmitted.
+	 * @throws FileUploadException if there are problems reading/parsing the request
+	 *                             or storing files.
+	 */
+	public List<FileItem> parseRepresentation(Representation multipartForm) throws FileUploadException {
+		return parseRequest(new RepresentationContext(multipartForm));
+	}
+
+	// [ifndef gae] method
+	/**
+	 * Processes an <a href="http://www.ietf.org/rfc/rfc1867.txt">RFC 1867</a>
+	 * compliant <code>multipart/form-data</code> input representation. Note that
+	 * this will result in the writing of the parts on the disk.
+	 * 
+	 * @param request The request containing the entity to be parsed.
+	 * @return A list of <code>FileItem</code> instances parsed, in the order that
+	 *         they were transmitted.
+	 * @throws FileUploadException if there are problems reading/parsing the request
+	 *                             or storing files.
+	 */
+	public List<FileItem> parseRequest(Request request) throws FileUploadException {
+		return parseRequest(new RepresentationContext(request.getEntity()));
+	}
 
 }


### PR DESCRIPTION
## The aim
Remove FileUpload extension variant using Servlet API

## The solution
Fully take advantage of Restlet API abstraction

## Reproduction
Tested using the org.restlet.example.book.restlet.ch07.sec1.sub5.MailApplication deployed standalone and in a Tomcat container.

@thboileau Could you review and merge if ok?