### PR TITLE
2.5 osgi bundles via maven plugin

### DIFF
--- a/modules/org.restlet.ext.atom/pom.xml
+++ b/modules/org.restlet.ext.atom/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.atom</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Atom</name>
 	<description>Support for the Atom syndication and the AtomPub (Atom Publication Protocol) standards in their 1.0 version.</description>
 
@@ -25,4 +26,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.crypto/pom.xml
+++ b/modules/org.restlet.ext.crypto/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.crypto</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Crypto</name>
 	<description>Support for cryptography.</description>
 
@@ -20,4 +21,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.fileupload/pom.xml
+++ b/modules/org.restlet.ext.fileupload/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.fileupload</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - FileUpload</name>
 	<description>Integration with Apache FileUpload.</description>
 
@@ -31,4 +32,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.freemarker/pom.xml
+++ b/modules/org.restlet.ext.freemarker/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.freemarker</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - FreeMarker</name>
 	<description>Integration with FreeMarker.</description>
 
@@ -25,4 +26,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.gae/pom.xml
+++ b/modules/org.restlet.ext.gae/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>org.restlet.ext.gae</artifactId>
+    <packaging>bundle</packaging>
     <name>Restlet Extension - GAE</name>
     <description>Integration to the Google App Engine UserService for the GAE edition.</description>
 
@@ -25,4 +26,13 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/org.restlet.ext.gson/pom.xml
+++ b/modules/org.restlet.ext.gson/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.gson</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - GSON</name>
 	<description>Support for GSON representations.</description>
 
@@ -30,4 +31,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.guice/pom.xml
+++ b/modules/org.restlet.ext.guice/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.guice</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Guice</name>
 	<description>Integration with Google Guice.</description>
 
@@ -40,4 +41,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.gwt/pom.xml
+++ b/modules/org.restlet.ext.gwt/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
 	<artifactId>org.restlet.ext.gwt</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - GWT</name>
 	<description>Server-side integration with GWT.</description>
 
@@ -36,4 +37,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.html/pom.xml
+++ b/modules/org.restlet.ext.html/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.html</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - HTML</name>
 	<description>Support for the HTML (HyperText Markup Language) standard in its 4.0 version and above.</description>
 
@@ -20,4 +21,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.httpclient/pom.xml
+++ b/modules/org.restlet.ext.httpclient/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.httpclient</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Apache HTTP Client</name>
 	<description>Integration with Apache Commons HTTP Client.</description>
 
@@ -55,4 +56,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.jaas/pom.xml
+++ b/modules/org.restlet.ext.jaas/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.jaas</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - JAAS</name>
 	<description>Support for JAAS based security.</description>
 
@@ -20,4 +21,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.jackson/pom.xml
+++ b/modules/org.restlet.ext.jackson/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.jackson</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Jackson</name>
 	<description>Integration with Jackson.</description>
 
@@ -65,4 +66,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.jaxb/pom.xml
+++ b/modules/org.restlet.ext.jaxb/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.jaxb</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - JAXB</name>
 	<description>Integration with Java XML Binding.</description>
 
@@ -36,4 +37,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.jetty/pom.xml
+++ b/modules/org.restlet.ext.jetty/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.jetty</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Jetty</name>
 	<description>Integration with Jetty.</description>
 
@@ -45,4 +46,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.json/pom.xml
+++ b/modules/org.restlet.ext.json/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.json</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - JSON</name>
 	<description>Support for JSON representations.</description>
 
@@ -25,4 +26,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.odata/pom.xml
+++ b/modules/org.restlet.ext.odata/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.odata</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - OData</name>
 	<description>Integration with OData services.</description>
 
@@ -40,4 +41,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.osgi/pom.xml
+++ b/modules/org.restlet.ext.osgi/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>org.restlet.ext.osgi</artifactId>
+    <packaging>bundle</packaging>
     <name>Restlet Extension - OSGi</name>
     <description>Support for the OSGi specification.</description>
 
@@ -32,4 +33,19 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Export-Package>org.restlet.ext.osgi</Export-Package>
+                        <Bundle-Activator>org.restlet.engine.ext.osgi.internal.Activator</Bundle-Activator>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/org.restlet.ext.rdf/pom.xml
+++ b/modules/org.restlet.ext.rdf/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.rdf</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - RDF</name>
 	<description>Support for the RDF parsing and generation.</description>
 
@@ -25,4 +26,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.servlet/pom.xml
+++ b/modules/org.restlet.ext.servlet/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>org.restlet.ext.servlet</artifactId>
+    <packaging>bundle</packaging>
     <name>Restlet Extension - Servlet</name>
     <description>Integration with Servlet API.</description>
 
@@ -26,4 +27,13 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/org.restlet.ext.slf4j/pom.xml
+++ b/modules/org.restlet.ext.slf4j/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.slf4j</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - SLF4J</name>
 	<description>Support for the SLF4J logging bridge.</description>
 
@@ -25,4 +26,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.spring/pom.xml
+++ b/modules/org.restlet.ext.spring/pom.xml
@@ -10,6 +10,7 @@
     </parent>
 
     <artifactId>org.restlet.ext.spring</artifactId>
+    <packaging>bundle</packaging>
     <name>Restlet Extension - Spring Framework</name>
     <description>Integration with Spring Framework.</description>
 
@@ -71,4 +72,13 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/org.restlet.ext.thymeleaf/pom.xml
+++ b/modules/org.restlet.ext.thymeleaf/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.thymeleaf</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Thymeleaf</name>
 	<description>Integration with Thymeleaf.</description>
 
@@ -25,4 +26,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.velocity/pom.xml
+++ b/modules/org.restlet.ext.velocity/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.velocity</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - Velocity</name>
 	<description>Integration with Apache Velocity.</description>
 
@@ -30,4 +31,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet.ext.xml/pom.xml
+++ b/modules/org.restlet.ext.xml/pom.xml
@@ -10,6 +10,7 @@
 	</parent>
 
 	<artifactId>org.restlet.ext.xml</artifactId>
+	<packaging>bundle</packaging>
 	<name>Restlet Extension - XML</name>
 	<description>Support for the XML documents.</description>
 
@@ -20,4 +21,13 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<extensions>true</extensions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/modules/org.restlet/pom.xml
+++ b/modules/org.restlet/pom.xml
@@ -11,6 +11,7 @@
 
     <artifactId>org.restlet</artifactId>
     <name>Restlet Core - API and Engine</name>
+    <packaging>bundle</packaging>
     <description>RESTful web framework for Java (API and Engine).</description>
 
     <dependencies>
@@ -28,4 +29,28 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Import-Package>com.sun.net.httpserver;resolution=optional,
+                            javax.net.ssl;resolution=optional,
+                            javax.security.auth.x500;resolution=optional,
+                            javax.xml.parsers;resolution=optional,
+                            org.osgi.framework;resolution:=optional,
+                            org.w3c.dom;resolution=optional,
+                            org.w3c.dom.ls;resolution=optional,
+                            org.xml.sax.*;resolution=optional,
+                            *
+                        </Import-Package>
+                        <Bundle-Activator>org.restlet.engine.internal.Activator</Bundle-Activator>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/modules/org.restlet/pom.xml
+++ b/modules/org.restlet/pom.xml
@@ -37,10 +37,6 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>
-                            org.osgi.framework;resolution:=optional,
-                            *
-                        </Import-Package>
                         <Bundle-Activator>org.restlet.engine.internal.Activator</Bundle-Activator>
                     </instructions>
                 </configuration>

--- a/modules/org.restlet/pom.xml
+++ b/modules/org.restlet/pom.xml
@@ -37,14 +37,8 @@
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>
-                        <Import-Package>com.sun.net.httpserver;resolution=optional,
-                            javax.net.ssl;resolution=optional,
-                            javax.security.auth.x500;resolution=optional,
-                            javax.xml.parsers;resolution=optional,
+                        <Import-Package>
                             org.osgi.framework;resolution:=optional,
-                            org.w3c.dom;resolution=optional,
-                            org.w3c.dom.ls;resolution=optional,
-                            org.xml.sax.*;resolution=optional,
                             *
                         </Import-Package>
                         <Bundle-Activator>org.restlet.engine.internal.Activator</Bundle-Activator>

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.4</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -439,6 +439,11 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>5.1.9</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
## The aim

Packages all jar as OSGi bundles (at least in this first step).
Has been tested manually with Felix OSGi container (simple restlet-based server and jackson deserialization). It should be fine to add a repository with sample code (not only for OSGi, but other tests like android, gae, etc) and README.

## The solution

Take benefit from the [maven-bundle-plugin](https://felix.apache.org/documentation/_attachments/components/bundle-plugin/index.html) in order to package modules as bundle (except GWT edition)

## Check-list

* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [ ] Added
    * [x] Not applicable (will be done later via a samples repository)
* Doc
    * [ ] Added
    * [ ] Not applicable
* Reviewer
    * [x] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
