### PR TITLE
fix(#1437) Deprecate html, fileupload and httpclient extensions

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -15,7 +15,7 @@ Changes log
       - Removed deprecation of GWT extension as the new intent is to keep the GWT edition and extension maintained in the new
         major 2.6 release.
       - Deprecated extensions (Apache) HTTP Client, HTML and (Apache) FileUpload as we intend to remove them in version 2.6 to
-        rely instead on the Jetty extension for a more robust alternative. 
+        rely instead on the Jetty extension for a more robust alternative. Issue #1437.
 
 - 2.5 Release Candidate 1 (12-11-2024)
     - Enhancements

--- a/org.restlet.java/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RepresentationContext.java
+++ b/org.restlet.java/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RepresentationContext.java
@@ -20,7 +20,9 @@ import org.restlet.representation.Representation;
  * processor.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class RepresentationContext implements UploadContext  {
 
     /** The representation to adapt. */

--- a/org.restlet.java/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RestletFileUpload.java
+++ b/org.restlet.java/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/RestletFileUpload.java
@@ -40,7 +40,9 @@ import org.restlet.representation.Representation;
  * method.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class RestletFileUpload extends FileUpload {
 	/**
 	 * Determines if the request has multipart content.

--- a/org.restlet.java/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/package.html
+++ b/org.restlet.java/org.restlet.ext.fileupload/src/main/java/org/restlet/ext/fileupload/package.html
@@ -5,5 +5,6 @@ Integration with Apache FileUpload 1.4 library. The Commons FileUpload package m
 @since Restlet 1.0
 @see <a href="https://commons.apache.org/proper/commons-fileupload/">Apache Commons FileUpload</a>
 @see <a href="https://restlet.talend.com/documentation/user-guide/2.5/extensions/fileupload">User Guide - Apache FileUpload extension</a>
+@deprecated Will be removed in next minor release in favor or Jetty extension.
 </BODY>
 </HTML>

--- a/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/FormData.java
+++ b/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/FormData.java
@@ -26,7 +26,9 @@ import org.restlet.util.NamedValue;
  * as a binary file uploaded).
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class FormData implements NamedValue<String> {
 
     /** The name of the associated form control. */

--- a/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/FormDataSet.java
+++ b/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/FormDataSet.java
@@ -28,7 +28,9 @@ import org.restlet.util.Series;
  * HTML form supporting either URL encoding or multipart encoding.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class FormDataSet extends OutputRepresentation {
 
     /** The default boundary separating multipart entries. */

--- a/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/HtmlConverter.java
+++ b/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/HtmlConverter.java
@@ -24,7 +24,9 @@ import org.restlet.resource.Resource;
  * Converter between the HTML API and Representation classes.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class HtmlConverter extends ConverterHelper {
 
     private static final VariantInfo VARIANT_MULTIPART = new VariantInfo(

--- a/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/internal/FormReader.java
+++ b/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/internal/FormReader.java
@@ -28,7 +28,9 @@ import org.restlet.util.Series;
  * Form reader.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class FormReader {
 
     /** The encoding to use, decoding is enabled, see {@link #decoding}. */

--- a/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/internal/FormUtils.java
+++ b/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/internal/FormUtils.java
@@ -27,7 +27,9 @@ import org.restlet.util.Series;
  * Representation of a Web form containing submitted entries.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class FormUtils {
 
     /**

--- a/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/package.html
+++ b/org.restlet.java/org.restlet.ext.html/src/main/java/org/restlet/ext/html/package.html
@@ -5,5 +5,6 @@ Support for the HTML (HyperText Markup Language) standard in its 4.0 version and
 @since Restlet 2.1
 @see <a href="http://www.w3.org/TR/html4/">W3C HTML 4.0 specification</a>
 @see <a href="https://restlet.talend.com/documentation/user-guide/2.5/extensions/html">User Guide - HTML extension</a>
+@deprecated Will be removed in next minor release in favor or Jetty extension.
 </BODY>
 </HTML>

--- a/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/HttpClientHelper.java
+++ b/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/HttpClientHelper.java
@@ -171,7 +171,9 @@ import org.restlet.ext.httpclient.internal.IgnoreCookieSpecFactory;
  *      href="https://docs.oracle.com/javase/1.5.0/docs/guide/net/index.html">Networking
  *      Features</a>
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class HttpClientHelper extends
         org.restlet.engine.adapter.HttpClientHelper {
     private volatile DefaultHttpClient httpClient;

--- a/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/HttpIdleConnectionReaper.java
+++ b/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/HttpIdleConnectionReaper.java
@@ -20,7 +20,9 @@ import org.apache.http.client.HttpClient;
  * is equal to 0.
  * 
  * @author Sanjay Acharya
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class HttpIdleConnectionReaper {
 
     /**

--- a/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/HttpMethodCall.java
+++ b/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/HttpMethodCall.java
@@ -48,7 +48,9 @@ import org.restlet.util.Series;
  * HTTP client connector call based on Apache HTTP Client's HttpMethod class.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class HttpMethodCall extends ClientCall {
 
     /** The associated HTTP client. */

--- a/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/IgnoreCookieSpec.java
+++ b/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/IgnoreCookieSpec.java
@@ -22,7 +22,9 @@ import org.apache.http.impl.cookie.CookieSpecBase;
  * Cookie specifications that ignore all cookies.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class IgnoreCookieSpec extends CookieSpecBase {
 
     /**

--- a/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/IgnoreCookieSpecFactory.java
+++ b/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/internal/IgnoreCookieSpecFactory.java
@@ -17,7 +17,9 @@ import org.apache.http.params.HttpParams;
  * Factory that creates {@link IgnoreCookieSpec} instances.
  * 
  * @author Jerome Louvel
+ * @deprecated Will be removed in next minor release in favor or Jetty extension.
  */
+@Deprecated
 public class IgnoreCookieSpecFactory implements CookieSpecFactory {
 
     /**

--- a/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/package.html
+++ b/org.restlet.java/org.restlet.ext.httpclient/src/main/java/org/restlet/ext/httpclient/package.html
@@ -7,5 +7,6 @@ support.
 @since Restlet 1.0
 @see <a href="https://hc.apache.org/httpcomponents-client-4.5.x/">Apache HTTP client project</a>
 @see <a href="https://restlet.talend.com/documentation/user-guide/2.5/extensions/httpclient">User Guide - Apache HTTP Client extension</a>
+@deprecated Will be removed in next minor release in favor or Jetty extension.
 </BODY>
 </HTML>


### PR DESCRIPTION
## The aim

Deprecated extensions (Apache) HTTP Client, HTML and (Apache) FileUpload as we intend to remove them in version 2.6 to rely instead on the Jetty extension for a more robust alternative. Issue #1437

## Check-list
* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [ ] Added
    * [x] Not applicable (just added deprecation annotations)
* Doc
    * [ ] Added
    * [x] Not applicable
* Reviewer
    * [x] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
