### PR TITLE
Bump guice to 7.0 and replace deprecated javax inject with jakarta inject

### DIFF
--- a/org.restlet.java/org.restlet.ext.guice/pom.xml
+++ b/org.restlet.java/org.restlet.ext.guice/pom.xml
@@ -21,11 +21,6 @@
 			<version>${lib-guice-version}</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.inject</groupId>
-			<artifactId>javax.inject</artifactId>
-			<version>${lib-javax-inject-version}</version>
-		</dependency>
-		<dependency>
 			<groupId>org.restlet</groupId>
 			<artifactId>org.restlet</artifactId>
 			<version>${project.version}</version>

--- a/org.restlet.java/org.restlet.ext.guice/src/main/java/org/restlet/ext/guice/ResourceInjectingApplication.java
+++ b/org.restlet.java/org.restlet.ext.guice/src/main/java/org/restlet/ext/guice/ResourceInjectingApplication.java
@@ -9,7 +9,7 @@
 
 package org.restlet.ext.guice;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.restlet.Application;
 import org.restlet.Request;

--- a/org.restlet.java/org.restlet.ext.guice/src/main/java/org/restlet/ext/guice/SelfInjectingServerResource.java
+++ b/org.restlet.java/org.restlet.ext.guice/src/main/java/org/restlet/ext/guice/SelfInjectingServerResource.java
@@ -11,7 +11,7 @@ package org.restlet.ext.guice;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.restlet.resource.ServerResource;
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,14 +68,13 @@
         <lib-gdata-version>1.0</lib-gdata-version>
         <lib-gson-version>2.10.1</lib-gson-version>
         <lib-guava-version>33.1.0-jre</lib-guava-version>
-        <lib-guice-version>6.0.0</lib-guice-version>
+        <lib-guice-version>7.0.0</lib-guice-version>
         <lib-gwt-version>2.11.0</lib-gwt-version>
         <lib-gwt-server-version>2.10.0</lib-gwt-server-version>
         <lib-hamcrest-version>1.3</lib-hamcrest-version>
         <lib-jackson-version>2.17.0</lib-jackson-version>
         <lib-jaxb-ri-version>2.4.0-b180830.0438</lib-jaxb-ri-version>
         <lib-jaxb-api-version>2.4.0-b180830.0359</lib-jaxb-api-version>
-        <lib-javax-inject-version>1</lib-javax-inject-version>
         <lib-jcip-annotations-version>1.0</lib-jcip-annotations-version>
         <lib-jetty-version>9.4.56.v20240826</lib-jetty-version>
         <lib-joda-time-version>2.12.7</lib-joda-time-version>


### PR DESCRIPTION
https://github.com/google/guice/wiki/Guice700

## The aim

With java 9 the javax.* namespace moved to jakarta.* (https://jakarta.ee/blogs/javax-jakartaee-namespace-ecosystem-progress/).
Since restlet minimum java version is now 17, we should also move to jakarta.*

## The solution

Replace javax.* with jakarta.* and bump guice to 7.0.0
