### PR TITLE
Fix issue #1448: wrong Engine's version

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -1,11 +1,15 @@
 Changes log
 ===========
 
+- 2.5.1 (28-01-2025)
+    - Bugs fixed
+        - Fixed Engine's version. Issue #1448
+
 - 2.5.0 (27-12-2024)
     - Security
        - Spring Framework before 6.0.0 suffers from a potential remote code execution (RCE) issue if used for Java deserialization
          of untrusted data. Depending on how the library is implemented within a product, this issue may or not occur, and
-         authentication may be required. Restlet Framework isn't able to upgrade to Spring Framewortk version 6.0 due to its
+         authentication may be required. Restlet Framework isn't able to upgrade to Spring Framework version 6.0 due to its
          requirement to use Java 8. If you are running Java 17+, please override the Spring dependency in your POM to version 6.0+
     - Bugs fixed
        - Fixed serialization issues in the GWT edition between client and server sides.

--- a/org.restlet.gwt/org.restlet.gwt/pom.xml
+++ b/org.restlet.gwt/org.restlet.gwt/pom.xml
@@ -25,8 +25,20 @@
 			<artifactId>gwt-dev</artifactId>
 			<version>${lib-gwt-version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>${lib-junit-version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
+		<testResources>
+			<testResource>
+				<directory>src/test/resources</directory>
+				<filtering>true</filtering>
+			</testResource>
+		</testResources>
 		<plugins>
 			<plugin>
 				<groupId>net.ltgt.gwt.maven</groupId>

--- a/org.restlet.gwt/org.restlet.gwt/src/main/java/org/restlet/client/data/Status.java
+++ b/org.restlet.gwt/org.restlet.gwt/src/main/java/org/restlet/client/data/Status.java
@@ -21,11 +21,7 @@ public final class Status {
 
     private static final String BASE_HTTP = "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html";
 
-    private static final String BASE_RESTLET = "http://restlet.org/learn/javadocs/"
-            + Engine.MAJOR_NUMBER
-            + '.'
-            + Engine.MINOR_NUMBER
-            + "/gwt/api/";
+    private static final String BASE_RESTLET = "https://javadoc.io/static/org.restlet.gwt/org.restlet.gwt/" + Engine.VERSION + "/";
 
 	@Deprecated
     private static final String BASE_WEBDAV = "http://www.webdav.org/specs/rfc2518.html";

--- a/org.restlet.gwt/org.restlet.gwt/src/main/java/org/restlet/client/engine/Engine.java
+++ b/org.restlet.gwt/org.restlet.gwt/src/main/java/org/restlet/client/engine/Engine.java
@@ -73,10 +73,10 @@ public class Engine {
     public static final String MAJOR_NUMBER = "2";
 
     /** Minor version number. */
-    public static final String MINOR_NUMBER = "4";
+    public static final String MINOR_NUMBER = "5";
 
     /** Release number. */
-    public static final String RELEASE_NUMBER = ".4";
+    public static final String RELEASE_NUMBER = "-SNAPSHOT";
 
 
     /** Complete version. */

--- a/org.restlet.gwt/org.restlet.gwt/src/test/java/org/restlet/client/engine/EngineTest.java
+++ b/org.restlet.gwt/org.restlet.gwt/src/test/java/org/restlet/client/engine/EngineTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2005-2024 Qlik
+ *
+ * The contents of this file is subject to the terms of the Apache 2.0 open
+ * source license available at http://www.opensource.org/licenses/apache-2.0
+ *
+ * Restlet is a registered trademark of QlikTech International AB.
+ */
+
+package org.restlet.client.engine;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EngineTest {
+
+    @Test
+    public void engineVersionShouldBeEqualToMavenProjectVersion() {
+        // When I retrieve the Maven project's version as stated in the pom file.
+        Properties properties = new Properties();
+        try (InputStream resourceAsStream = EngineTest.class.getClassLoader().getResourceAsStream("maven-version.properties")) {
+            properties.load(resourceAsStream);
+        } catch (IOException e) {
+            Assertions.fail("Can't load the properties file that contain the Maven's project version");
+        }
+
+        // Then the Maven project's version should be equal to the Engine's version.
+        assertEquals(Engine.VERSION, properties.getProperty("maven.version"));
+    }
+}

--- a/org.restlet.gwt/org.restlet.gwt/src/test/resources/maven-version.properties
+++ b/org.restlet.gwt/org.restlet.gwt/src/test/resources/maven-version.properties
@@ -1,0 +1,1 @@
+maven.version=${project.version}

--- a/org.restlet.java/org.restlet/pom.xml
+++ b/org.restlet.java/org.restlet/pom.xml
@@ -30,6 +30,12 @@
         </dependency>
     </dependencies>
     <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/org.restlet.java/org.restlet/src/main/java/org/restlet/data/Status.java
+++ b/org.restlet.java/org.restlet/src/main/java/org/restlet/data/Status.java
@@ -21,8 +21,7 @@ public final class Status {
 
 	private static final String BASE_HTTP = "http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html";
 
-	private static final String BASE_RESTLET = "https://javadocs.restlet.talend.com/" + Engine.MAJOR_NUMBER + '.'
-			+ Engine.MINOR_NUMBER + "/api/";
+	private static final String BASE_RESTLET = "https://javadoc.io/static/org.restlet/org.restlet/" + Engine.VERSION + "/";
 
 	@Deprecated
 	private static final String BASE_WEBDAV = "http://www.webdav.org/specs/rfc2518.html";

--- a/org.restlet.java/org.restlet/src/main/java/org/restlet/engine/Engine.java
+++ b/org.restlet.java/org.restlet/src/main/java/org/restlet/engine/Engine.java
@@ -90,9 +90,9 @@ public class Engine {
 	public static final String MINOR_NUMBER = "5";
 
 	/** Release number. */
-	public static final String RELEASE_NUMBER = "-RC1";
+	public static final String RELEASE_NUMBER = "-SNAPSHOT";
 
-	/** The org.restlet log level . */
+	/** The org.restlet log level. */
 	private static volatile Level restletLogLevel;
 
 	/** Complete version. */

--- a/org.restlet.java/org.restlet/src/test/java/org/restlet/engine/EngineTest.java
+++ b/org.restlet.java/org.restlet/src/test/java/org/restlet/engine/EngineTest.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2005-2024 Qlik
+ *
+ * The contents of this file is subject to the terms of the Apache 2.0 open
+ * source license available at http://www.opensource.org/licenses/apache-2.0
+ *
+ * Restlet is a registered trademark of QlikTech International AB.
+ */
+
+package org.restlet.engine;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class EngineTest {
+
+    @Test
+    public void engineVersionShouldBeEqualToMavenProjectVersion() {
+        // When I retrieve the Maven project's version as stated in the pom file.
+        Properties properties = new Properties();
+        try (InputStream resourceAsStream = EngineTest.class.getClassLoader().getResourceAsStream("maven-version.properties")) {
+            properties.load(resourceAsStream);
+        } catch (IOException e) {
+            Assertions.fail("Can't load the properties file that contain the Maven's project version");
+        }
+
+        // Then the Maven project's version should be equal to the Engine's version.
+        assertEquals(Engine.VERSION, properties.getProperty("maven.version"));
+    }
+}

--- a/org.restlet.java/org.restlet/src/test/resources/maven-version.properties
+++ b/org.restlet.java/org.restlet/src/test/resources/maven-version.properties
@@ -1,0 +1,1 @@
+maven.version=${project.version}


### PR DESCRIPTION
## The aim

The class Engine defines the version of the Restlet Framework at runtime. It is used for instance for generating `user agent` or `server` header.
When releasing the version `2.5.0`, a wrong version has been set. let's fix that.
In addition, a test case has been added to check the Maven version and the value in the code are correct.

## Check-list

* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [x] Added
    * [ ] Not applicable (why?)
* Doc
    * [ ] Added
    * [x] Not applicable
* Reviewer
    * [x] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
