### PR TITLE
Issue #1487: reuse Random instance

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -2,7 +2,8 @@ Changes log
 ===========
 
 - 2.7 Milestone 3 (??-??-2025)
-
+  - Bugs fixed
+    - Reuse an instance of Random class in RandomUtils. Issue #1487.
 - 2.7 Milestone 2 (29-06-2025)
     - Misc
       - Removed deprecated Servlet extension and related classes in Spring extension

--- a/org.restlet/src/main/java/org/restlet/routing/Router.java
+++ b/org.restlet/src/main/java/org/restlet/routing/Router.java
@@ -34,7 +34,7 @@ import java.util.logging.Level;
  * <li>First match (default)</li>
  * <li>Last match</li>
  * <li>Random match</li>
- * <li>Round robin</li>
+ * <li>Round-robin</li>
  * <li>Custom</li>
  * </ul>
  * <br>
@@ -53,7 +53,7 @@ import java.util.logging.Level;
 public class Router extends Restlet {
 
 	/**
-	 * Each call will be routed to the route with the best score, if the required
+	 * Each call will be routed to the route with the best score if the required
 	 * score is reached. See {@link RouteList#getBest(Request, Response, float)}
 	 * method for implementation details.
 	 */
@@ -94,7 +94,7 @@ public class Router extends Restlet {
 
 	/**
 	 * Each call will be randomly routed to one of the routes that reached the
-	 * required score. If the random route selected is not a match then the
+	 * required score. If the random route selected is not a match, then the
 	 * immediate next route is evaluated until one matching route is found. If we
 	 * get back to the initial random route selected with no match, then we return
 	 * null. Unless all the routes score above the required score, this mode will

--- a/org.restlet/src/main/java/org/restlet/util/RouteList.java
+++ b/org.restlet/src/main/java/org/restlet/util/RouteList.java
@@ -14,6 +14,7 @@ import org.restlet.Response;
 import org.restlet.Restlet;
 import org.restlet.routing.Route;
 
+import java.security.SecureRandom;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
@@ -34,14 +35,16 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @see java.util.List
  */
 public final class RouteList extends WrapperList<Route> {
-	/** The index of the last route used in the round robin mode. */
+	/** The index of the last route used in the round-robin mode. */
 	private volatile int lastIndex;
+	/** Used when asked to return a random route. */
+	private final SecureRandom random = new SecureRandom();
 
 	/**
 	 * Constructor.
 	 */
 	public RouteList() {
-		super(new CopyOnWriteArrayList<Route>());
+		super(new CopyOnWriteArrayList<>());
 		this.lastIndex = -1;
 	}
 
@@ -51,7 +54,7 @@ public final class RouteList extends WrapperList<Route> {
 	 * @param delegate The delegate list.
 	 */
 	public RouteList(List<Route> delegate) {
-		super(new CopyOnWriteArrayList<Route>(delegate));
+		super(new CopyOnWriteArrayList<>(delegate));
 		this.lastIndex = -1;
 	}
 
@@ -159,7 +162,7 @@ public final class RouteList extends WrapperList<Route> {
 		int length = size();
 
 		if (length > 0) {
-			int j = new Random().nextInt(length);
+			int j = random.nextInt(length);
 			Route route = get(j);
 
 			if (route.score(request, response) >= requiredScore) {
@@ -169,7 +172,7 @@ public final class RouteList extends WrapperList<Route> {
 			boolean loopedAround = false;
 
 			do {
-				if ((j == length) && (!loopedAround)) {
+				if ((j == length) && !loopedAround) {
 					j = 0;
 					loopedAround = true;
 				}
@@ -187,7 +190,7 @@ public final class RouteList extends WrapperList<Route> {
 	}
 
 	/**
-	 * Removes all routes routing to a given target.
+	 * Removes all routes to a given target.
 	 * 
 	 * @param target The target Restlet to detach.
 	 */


### PR DESCRIPTION
## The aim

Creating a new Random object each time a random value is needed is inefficient and may produce numbers that are not random, depending on the JDK. For better efficiency and randomness, create a single Random, store it, and reuse it.

The Random() constructor tries to set the seed with a distinct value every time. However, there is no guarantee that the seed will be randomly or uniformly distributed. Some JDK will use the current time as seed, making the generated numbers not random.

## The solution

Use an instance member.

## Check-list

* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [ ] Added
    * [x] Not applicable (why?)
* Doc
    * [ ] Added
    * [x] Not applicable
* Reviewer
    * [x] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
