### PR TITLE
Issue #1495: Avoid non-short-circuit logic in FileClientHelper

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -5,6 +5,7 @@ Changes log
     - Bugs fixed
         - Reuse an instance of Random class in RandomUtils. Issue #1487.
         - Complete test classes. Issue #1490.
+        - Avoid non-short-circuit logic in FileClientHelper. Issue #1495.
 - 
 - 2.6.0 (29-06-2025)
 

--- a/org.restlet.java/org.restlet/src/main/java/org/restlet/engine/local/FileClientHelper.java
+++ b/org.restlet.java/org.restlet/src/main/java/org/restlet/engine/local/FileClientHelper.java
@@ -106,7 +106,7 @@ public class FileClientHelper extends EntityClientHelper {
 	 * 
 	 * @param fileName       The name of the resource
 	 * @param representation The provided representation.
-	 * @return True if the metadata of the representation are compatible with the
+	 * @return True if the metadata of the representation is compatible with the
 	 *         metadata extracted from the filename
 	 */
 	private boolean checkMetadataConsistency(String fileName, Representation representation) {
@@ -208,7 +208,7 @@ public class FileClientHelper extends EntityClientHelper {
 			final String fileAbsolute = directory.getRootRef().getPath(true);
 			final String filePath;
 
-			if (fileAbsolute.indexOf(':') == 2 | fileAbsolute.indexOf('|') == 2) {
+			if (fileAbsolute.indexOf(':') == 2 || fileAbsolute.indexOf('|') == 2) {
 				filePath = fileAbsolute.substring(1);
 			} else {
 				filePath = fileAbsolute;
@@ -541,7 +541,7 @@ public class FileClientHelper extends EntityClientHelper {
 	}
 
 	private void cleanTemporaryFileIfUploadNotResumed(File tmp) {
-		if (tmp.exists() && !isResumeUpload()) {
+		if (tmp!= null && tmp.exists() && !isResumeUpload()) {
 			IoUtils.delete(tmp);
 		}
 	}
@@ -567,18 +567,14 @@ public class FileClientHelper extends EntityClientHelper {
 		boolean defaultMetadata = true;
 
 		if (getMetadataService() != null) {
-			if (metadata instanceof Language) {
-				Language language = (Language) metadata;
-				defaultMetadata = language.equals(getMetadataService().getDefaultLanguage());
-			} else if (metadata instanceof MediaType) {
-				MediaType mediaType = (MediaType) metadata;
-				defaultMetadata = mediaType.equals(getMetadataService().getDefaultMediaType());
-			} else if (metadata instanceof CharacterSet) {
-				CharacterSet characterSet = (CharacterSet) metadata;
-				defaultMetadata = characterSet.equals(getMetadataService().getDefaultCharacterSet());
-			} else if (metadata instanceof Encoding) {
-				Encoding encoding = (Encoding) metadata;
-				defaultMetadata = encoding.equals(getMetadataService().getDefaultEncoding());
+			if (metadata instanceof final Language language) {
+                defaultMetadata = language.equals(getMetadataService().getDefaultLanguage());
+			} else if (metadata instanceof final MediaType mediaType) {
+                defaultMetadata = mediaType.equals(getMetadataService().getDefaultMediaType());
+			} else if (metadata instanceof final CharacterSet characterSet) {
+                defaultMetadata = characterSet.equals(getMetadataService().getDefaultCharacterSet());
+			} else if (metadata instanceof final Encoding encoding) {
+                defaultMetadata = encoding.equals(getMetadataService().getDefaultEncoding());
 			}
 		}
 


### PR DESCRIPTION
## The aim

Avoid non-short-circuit logic in FileClientHelper

## Check-list

* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [ ] Added
    * [x] Not applicable (why?)
* Doc
    * [ ] Added
    * [x] Not applicable
* Reviewer
    * [x] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
