### PR TITLE
Issue #1495: Avoid non-short-circuit logic in FileClientHelper

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -3,8 +3,9 @@ Changes log
 
 - 2.7 Milestone 3 (??-??-2025)
   - Bugs fixed
-    - Reuse an instance of Random class in RandomUtils. Issue #1487.
-    - Complete test classes. Issue #1490.
+      - Reuse an instance of Random class in RandomUtils. Issue #1487.
+      - Complete test classes. Issue #1490.
+      - Avoid non-short-circuit logic in FileClientHelper. Issue #1495.
 
 - 2.7 Milestone 2 (29-06-2025)
     - Misc

--- a/org.restlet/src/main/java/org/restlet/engine/local/FileClientHelper.java
+++ b/org.restlet/src/main/java/org/restlet/engine/local/FileClientHelper.java
@@ -205,7 +205,7 @@ public class FileClientHelper extends EntityClientHelper {
 			final String fileAbsolute = directory.getRootRef().getPath(true);
 			final String filePath;
 
-			if (fileAbsolute.indexOf(':') == 2 | fileAbsolute.indexOf('|') == 2) {
+			if (fileAbsolute.indexOf(':') == 2 || fileAbsolute.indexOf('|') == 2) {
 				filePath = fileAbsolute.substring(1);
 			} else {
 				filePath = fileAbsolute;


### PR DESCRIPTION
## The aim

Avoid non-short-circuit logic in FileClientHelper

## Check-list

* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [ ] Added
    * [x] Not applicable (why?)
* Doc
    * [ ] Added
    * [x] Not applicable
* Reviewer
    * [x] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
