### PR TITLE
Issue #1498: Drop the implementations of the clone method.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -6,6 +6,7 @@ Changes log
       - Reuse an instance of Random class in RandomUtils. Issue #1487.
       - Complete test classes. Issue #1490.
       - Avoid non-short-circuit logic in FileClientHelper. Issue #1495.
+      - Drop the implementations of the clone method. Issue #1498.
 
 - 2.7 Milestone 2 (29-06-2025)
     - Misc

--- a/org.restlet/src/main/java/org/restlet/data/Reference.java
+++ b/org.restlet/src/main/java/org/restlet/data/Reference.java
@@ -638,8 +638,7 @@ public class Reference {
 		return this;
 	}
 
-	@Override
-	public Reference clone() {
+	public Reference copy() {
 		final Reference newRef = new Reference();
 
 		if (this.baseRef == null) {
@@ -647,7 +646,7 @@ public class Reference {
 		} else if (equals(this.baseRef)) {
 			newRef.baseRef = newRef;
 		} else {
-			newRef.baseRef = this.baseRef.clone();
+			newRef.baseRef = this.baseRef.copy();
 		}
 
 		newRef.fragmentIndex = this.fragmentIndex;

--- a/org.restlet/src/main/java/org/restlet/engine/util/ImmutableDate.java
+++ b/org.restlet/src/main/java/org/restlet/engine/util/ImmutableDate.java
@@ -35,7 +35,7 @@ public final class ImmutableDate extends Date {
 
 	/** {@inheritDoc} */
 	@Override
-	public Object clone() {
+	public Object clone() throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("ImmutableDate is immutable");
 	}
 


### PR DESCRIPTION
## The aim

Drop the existing implementations of the clone method.
cf https://github.com/restlet/restlet-framework-java/issues/1498

## Check-list

* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [ ] Added
    * [x] Not applicable (why?)
* Doc
    * [ ] Added
    * [x] Not applicable
* Reviewer
    * [ ] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
