### PR TITLE
Issue #1498: Deprecate the implementations of the clone method.

### DIFF
--- a/changes.md
+++ b/changes.md
@@ -5,7 +5,7 @@ Changes log
     - Bugs fixed
         - Reuse an instance of Random class in RandomUtils. Issue #1487.
         - Complete test classes. Issue #1490.
-- 
+-       - Deprecate the implementations of the clone method. Issue #1498.
 - 2.6.0 (29-06-2025)
 
 - 2.6 Release Candidate 2 (21-06-2025)

--- a/org.restlet.gwt/org.restlet.gwt/src/main/java/org/restlet/client/engine/util/ImmutableDate.java
+++ b/org.restlet.gwt/org.restlet.gwt/src/main/java/org/restlet/client/engine/util/ImmutableDate.java
@@ -38,7 +38,7 @@ public final class ImmutableDate extends Date {
 
 	/** {@inheritDoc} */
 	@Override
-	public Object clone() {
+	public Object clone() throws UnsupportedOperationException {
 		throw new UnsupportedOperationException("ImmutableDate is immutable");
 	}
 

--- a/org.restlet.java/org.restlet/src/main/java/org/restlet/data/Reference.java
+++ b/org.restlet.java/org.restlet/src/main/java/org/restlet/data/Reference.java
@@ -638,8 +638,16 @@ public class Reference {
 		return this;
 	}
 
+	/**
+	 * @deprecated Use the {@code copy} method instead.
+	 */
 	@Override
+	@Deprecated
 	public Reference clone() {
+		return copy();
+	}
+
+	public Reference copy() {
 		final Reference newRef = new Reference();
 
 		if (this.baseRef == null) {
@@ -647,7 +655,7 @@ public class Reference {
 		} else if (equals(this.baseRef)) {
 			newRef.baseRef = newRef;
 		} else {
-			newRef.baseRef = this.baseRef.clone();
+			newRef.baseRef = this.baseRef.copy();
 		}
 
 		newRef.fragmentIndex = this.fragmentIndex;


### PR DESCRIPTION
## The aim

Deprecate the existing implementations of the clone method.
cf https://github.com/restlet/restlet-framework-java/issues/1498

## Check-list

* PR size
    * [x] Under 300 lines :white_check_mark:
    * [ ] Can't be split without complicating the process even more
* Tests
    * [ ] Added
    * [x] Not applicable (why?)
* Doc
    * [ ] Added
    * [x] Not applicable
* Reviewer
    * [ ] Asked for a review
    * [ ] Added label `DO NOT REVIEW`
